### PR TITLE
Handle html error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-<!-- ## [Unreleased] -->
+## [Unreleased]
 
-## [0.7.0] - 2024-06-23
+<!-- ## [0.7.0] - 2024-06-23 -->
 
 ### Added
 
@@ -115,7 +115,7 @@ Disabled `reqwest`'s default features and enabled `rustls-tls`.
 
 Initial release.
 
-[0.7.0]: https://crates.io/crates/resend-rs/0.7.0
+<!-- [0.7.0]: https://crates.io/crates/resend-rs/0.7.0 -->
 [0.6.0]: https://crates.io/crates/resend-rs/0.6.0
 [0.5.2]: https://crates.io/crates/resend-rs/0.5.2
 [0.5.1]: https://crates.io/crates/resend-rs/0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to
 
 <!-- ## [Unreleased] -->
 
+## [0.7.0] - 2024-06-23
+
+### Added
+
+- `Error::Parse` variant
+
+### Changed
+
+- HTML server responses instead of proper JSON errors (which should mostly happen in outages)
+  now have better error messages
+
+
 ## [0.6.0] - 2024-06-16
 
 ### Changed
@@ -103,6 +115,7 @@ Disabled `reqwest`'s default features and enabled `rustls-tls`.
 
 Initial release.
 
+[0.7.0]: https://crates.io/crates/resend-rs/0.7.0
 [0.6.0]: https://crates.io/crates/resend-rs/0.6.0
 [0.5.2]: https://crates.io/crates/resend-rs/0.5.2
 [0.5.1]: https://crates.io/crates/resend-rs/0.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "resend-rs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 license = "MIT"

--- a/src/audiences.rs
+++ b/src/audiences.rs
@@ -150,6 +150,7 @@ pub mod types {
     #[derive(Debug, Clone, Deserialize)]
     pub struct RemoveAudienceResponse {
         /// The ID of the audience.
+        #[allow(dead_code)]
         pub id: AudienceId,
         /// The deleted attribute indicates that the corresponding audience has been deleted.
         pub deleted: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,17 @@ impl Config {
 
         match response.status() {
             x if x.is_client_error() || x.is_server_error() => {
+                // TODO: Make this more testable
+                let content_type_is_html = response
+                    .headers()
+                    .get("content-type")
+                    .and_then(|el| el.to_str().ok())
+                    .is_some_and(|content_type| content_type.contains("html"));
+
+                if content_type_is_html {
+                    return Err(Error::Parse(response.text().await?));
+                }
+
                 let error = response.json::<ErrorResponse>().await?;
                 Err(Error::Resend(error))
             }

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -289,6 +289,7 @@ pub mod types {
     #[derive(Debug, Clone, Deserialize)]
     pub struct DeleteContactResponse {
         /// The ID of the domain.
+        #[allow(dead_code)]
         pub contact: ContactId,
         /// Indicates whether the domain was deleted successfully.
         pub deleted: bool,

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -316,6 +316,7 @@ pub mod types {
     #[derive(Debug, Clone, Deserialize)]
     pub struct VerifyDomainResponse {
         /// The ID of the domain.
+        #[allow(dead_code)]
         pub id: DomainId,
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,10 @@ pub enum Error {
     /// Errors that may occur during the processing of the API request.
     #[error("resend error: {0}")]
     Resend(#[from] types::ErrorResponse),
+
+    /// Errors that may occur during the parsing of an API response.
+    #[error("Failed to parse Resend API response. Received: \n{0}")]
+    Parse(String),
 }
 
 /// Specialized [`Result`] type for an [`Error`].


### PR DESCRIPTION
Adds new error variant for when the server returns html instead of json. Set to unreleased for now as this should not happen outside of outages anyway in order to add a few tests before releasing.