### PR TITLE
feat(error): allow ErrorKind to be compared

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -27,7 +27,7 @@ pub mod types {
     ///
     /// [`Resend`]: crate::Resend
     #[non_exhaustive]
-    #[derive(Debug, Copy, Clone)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub enum ErrorKind {
         /// Error name is not in the API spec.
         Unrecognized,


### PR DESCRIPTION
The `ErrorKind` enum does not implement the `PartialEq` trait which makes for simple comparisons on the `error_response.kind()` function tedious. With this change the following becomes possible:
```rust
impl From<resend_rs::Error> for Error {
    fn from(value: resend_rs::Error) -> Self {
        match value {
            resend_rs::Error::Resend(error_response)
                if error_response.kind() == resend_rs::types::ErrorKind::InvalidToAddress =>
            {
                todo!()
            }
            _ => todo!(),
        }
    }
}
```