### PR TITLE
feat(domains): add Tracking and TrackingCAA record support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 <!--## Unreleased-->
 
+## [0.24.0] - 2026-04-16
+
+### Added 
+
+- `TrackingRecord` and `TrackingCaaRecord` in `ProxyStatus`
+
 ## [0.23.0] - 2026-04-12
 
 ### Added
@@ -483,6 +489,7 @@ Disabled `reqwest`'s default features and enabled `rustls-tls`.
 
 Initial release.
 
+[0.24.0]: https://crates.io/crates/resend-rs/0.24.0
 [0.23.0]: https://crates.io/crates/resend-rs/0.23.0
 [0.22.0]: https://crates.io/crates/resend-rs/0.22.0
 [0.21.1]: https://crates.io/crates/resend-rs/0.21.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "resend-rs"
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 
 license = "MIT"

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -311,10 +311,52 @@ pub mod types {
         pub priority: i32,
     }
 
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct TrackingRecord {
+        /// The name of the record.
+        pub name: String,
+        /// The value of the record.
+        pub value: String,
+        /// The type of record.
+        #[serde(rename = "type")]
+        pub r#type: TrackingRecordType,
+        /// The time to live for the record.
+        pub ttl: String,
+        /// The status of the record.
+        pub status: DomainStatus,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct TrackingCaaRecord {
+        /// The name of the record.
+        pub name: String,
+        /// The value of the record (e.g. `0 issue "amazon.com"`).
+        pub value: String,
+        /// The type of record.
+        #[serde(rename = "type")]
+        pub r#type: TrackingCaaRecordType,
+        /// The time to live for the record.
+        pub ttl: String,
+        /// The status of the record.
+        pub status: DomainStatus,
+    }
+
     #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
     pub enum ReceivingRecordType {
         #[allow(clippy::upper_case_acronyms)]
         MX,
+    }
+
+    #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+    pub enum TrackingRecordType {
+        #[allow(clippy::upper_case_acronyms)]
+        CNAME,
+    }
+
+    #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+    pub enum TrackingCaaRecordType {
+        #[allow(clippy::upper_case_acronyms)]
+        CAA,
     }
 
     #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -358,6 +400,10 @@ pub mod types {
         DomainDkimRecord(DomainDkimRecord),
         #[serde(rename = "Receiving MX")]
         ReceivingRecord(ReceivingRecord),
+        #[serde(rename = "Tracking")]
+        TrackingRecord(TrackingRecord),
+        #[serde(rename = "TrackingCAA")]
+        TrackingCaaRecord(TrackingCaaRecord),
     }
 
     /// Details of an existing domain.
@@ -524,5 +570,44 @@ mod test {
         assert!(list.is_empty());
 
         Ok(())
+    }
+
+    #[test]
+    fn deserialize_domain_with_tracking_caa_record() {
+        use crate::domains::types::{Domain, DomainRecord};
+
+        let json = r#"{
+            "object": "domain",
+            "id": "7c2a439f-d5fc-4dc1-8bab-ced17f14c972",
+            "name": "namingishard.dev",
+            "created_at": "2026-04-14 11:16:24.808219+00",
+            "status": "verified",
+            "capabilities": { "sending": "enabled", "receiving": "disabled" },
+            "records": [
+                {
+                    "record": "Tracking",
+                    "type": "CNAME",
+                    "name": "links",
+                    "value": "links1.resend-dns-staging.com",
+                    "ttl": "Auto",
+                    "status": "verified"
+                },
+                {
+                    "record": "TrackingCAA",
+                    "name": "",
+                    "type": "CAA",
+                    "ttl": "Auto",
+                    "value": "0 issue \"amazon.com\"",
+                    "status": "verified"
+                }
+            ],
+            "region": "eu-west-1"
+        }"#;
+
+        let domain: Domain = serde_json::from_str(json).expect("domain deserializes");
+        let records = domain.records.expect("records present");
+        assert_eq!(records.len(), 2);
+        assert!(matches!(records[0], DomainRecord::TrackingRecord(_)));
+        assert!(matches!(records[1], DomainRecord::TrackingCaaRecord(_)));
     }
 }

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -573,6 +573,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::indexing_slicing)]
     fn deserialize_domain_with_tracking_caa_record() {
         use crate::domains::types::{Domain, DomainRecord};
 


### PR DESCRIPTION
## Summary

The Domains API returns two record variants the Rust SDK was not yet modeling:

- **`Tracking`** (CNAME) — the custom click-tracking subdomain CNAME, emitted whenever `tracking_subdomain` is set on the domain.
- **`TrackingCAA`** (CAA, value `0 issue "amazon.com"`) — emitted on top of `Tracking` when the customer's root domain has CAA records that would prevent AWS from issuing a certificate for the tracking subdomain.

Without these variants the `DomainRecord` enum (which uses `#[serde(tag = "record")]`) failed to deserialize any domain that had click tracking enabled.

Adds both as new variants plus a deserialize test against the example payload.

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

## Test plan

- [ ] CI runs `cargo build` and `cargo test` (no local Rust toolchain available to run them here)
- [x] New `deserialize_domain_with_tracking_caa_record` test feeds the example payload through `serde_json::from_str::<Domain>` and asserts both variants land in the right enum arms.

Tracking: [Linear ENG-4849](https://linear.app/resend/issue/ENG-4849/rust)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Tracking` (CNAME) and `TrackingCAA` (CAA) record support to the Domains Rust SDK, fixing deserialization for domains with click tracking enabled. Aligns with ENG-4849 by modeling records emitted when `tracking_subdomain` is set and when CAA restricts AWS cert issuance.

- **New Features**
  - Added `TrackingRecord` and `TrackingCaaRecord` plus `DomainRecord` variants `Tracking` and `TrackingCAA`.
  - Added `deserialize_domain_with_tracking_caa_record` test to ensure correct `serde` deserialization.

- **Dependencies**
  - Bumped `resend-rs` to `0.24.0` and updated `CHANGELOG.md`.

<sup>Written for commit 3f08ad51541f6908bddbed21c9fc2355be70648b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

