### PR TITLE
fix: add new domain statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ and this project adheres to
   - `DomainDkimRecord.status`
   - `ReceivingRecord.status`
   - `TrackingRecord.status`
-- `DomainStatus` has additional options: `NotStarted`, `PartiallyStarted`, `PartiallyFailed`
+  - `TrackingCaaRecord.status`
+- `DomainStatus` has additional options: `NotStarted`, `PartiallyVerified`, `PartiallyFailed`
 
 ## [0.24.0] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+<!--## Unreleased-->
+
+## [0.25.0] - 2026-04-20
 
 ### Added
 
 - `Other` error variant
+- `DomainRecordStatus`
 
 ### Changed
 
 - the parse error variant went from `Parse(String)` to `Parse: {message: String, source: Option<Error>}`.
 - some errors that used to be `::Parse` are now instead `::Other` (these were very odd edge cases though, chances are you didn't run into them)
+- The following are now of type `DomainRecordStatus` instead of `DomainStatus`:
+  - `DomainSpfRecord.status`
+  - `DomainDkimRecord.status`
+  - `ReceivingRecord.status`
+  - `TrackingRecord.status`
+- `DomainStatus` has additional options: `NotStarted`, `PartiallyStarted`, `PartiallyFailed`
 
 ## [0.24.0] - 2026-04-16
 
@@ -502,6 +511,7 @@ Disabled `reqwest`'s default features and enabled `rustls-tls`.
 
 Initial release.
 
+[0.25.0]: https://crates.io/crates/resend-rs/0.25.0
 [0.24.0]: https://crates.io/crates/resend-rs/0.24.0
 [0.23.0]: https://crates.io/crates/resend-rs/0.23.0
 [0.22.0]: https://crates.io/crates/resend-rs/0.22.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "resend-rs"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 
 license = "MIT"
@@ -35,8 +35,8 @@ ecow = { version = "0.2.4", features = ["serde"] }
 thiserror = { version = "2.0" }
 maybe-async = { version = "0.2.10" }
 governor = "0.10.0"
-rand = "0.10.0"
-getrandom = { version = "0.4.1", features = ["wasm_js"] }
+rand = "0.10.1"
+getrandom = { version = "0.4.2", features = ["wasm_js"] }
 serde_json = "1.0.145"
 mailparse = "0.16.1"
 

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -268,7 +268,7 @@ pub mod types {
         /// The time to live for the record.
         pub ttl: String,
         /// The status of the record.
-        pub status: DomainStatus,
+        pub status: DomainRecordStatus,
 
         pub routing_policy: Option<String>,
         pub priority: Option<i32>,
@@ -287,7 +287,7 @@ pub mod types {
         /// The time to live for the record.
         pub ttl: String,
         /// The status of the record.
-        pub status: DomainStatus,
+        pub status: DomainRecordStatus,
 
         pub routing_policy: Option<String>,
         pub priority: Option<i32>,
@@ -306,7 +306,7 @@ pub mod types {
         /// The time to live for the record.
         pub ttl: String,
         /// The status of the record.
-        pub status: DomainStatus,
+        pub status: DomainRecordStatus,
 
         pub priority: i32,
     }
@@ -323,7 +323,7 @@ pub mod types {
         /// The time to live for the record.
         pub ttl: String,
         /// The status of the record.
-        pub status: DomainStatus,
+        pub status: DomainRecordStatus,
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -338,7 +338,7 @@ pub mod types {
         /// The time to live for the record.
         pub ttl: String,
         /// The status of the record.
-        pub status: DomainStatus,
+        pub status: DomainRecordStatus,
     }
 
     #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -368,6 +368,17 @@ pub mod types {
     #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
     #[serde(rename_all = "snake_case")]
     pub enum DomainStatus {
+        Pending,
+        Verified,
+        Failed,
+        NotStarted,
+        PartiallyVerified,
+        PartiallyFailed,
+    }
+
+    #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+    #[serde(rename_all = "snake_case")]
+    pub enum DomainRecordStatus {
         Pending,
         Verified,
         Failed,
@@ -610,5 +621,41 @@ mod test {
         assert_eq!(records.len(), 2);
         assert!(matches!(records[0], DomainRecord::TrackingRecord(_)));
         assert!(matches!(records[1], DomainRecord::TrackingCaaRecord(_)));
+    }
+
+    #[test]
+    fn deserialize_partially_verified_domain() {
+        use crate::domains::types::{Domain, DomainStatus};
+
+        let json = r#"{
+            "object": "domain",
+            "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+            "name": "resend.com",
+            "status": "partially_verified",
+            "created_at": "2023-06-21T06:10:36.144Z",
+            "region": "us-east-1",
+            "capabilities": { "sending": "enabled", "receiving": "disabled" }
+        }"#;
+
+        let domain: Domain = serde_json::from_str(json).expect("domain deserializes");
+        assert!(matches!(domain.status, DomainStatus::PartiallyVerified));
+    }
+
+    #[test]
+    fn deserialize_partially_failed_domain() {
+        use crate::domains::types::{Domain, DomainStatus};
+
+        let json = r#"{
+            "object": "domain",
+            "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+            "name": "resend.com",
+            "status": "partially_failed",
+            "created_at": "2023-06-21T06:10:36.144Z",
+            "region": "us-east-1",
+            "capabilities": { "sending": "enabled", "receiving": "enabled" }
+        }"#;
+
+        let domain: Domain = serde_json::from_str(json).expect("domain deserializes");
+        assert!(matches!(domain.status, DomainStatus::PartiallyFailed));
     }
 }

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -540,7 +540,7 @@ mod test {
 
     #[tokio_shared_rt::test(shared = true)]
     #[cfg(not(feature = "blocking"))]
-    #[ignore = "Flaky backend"]
+    // #[ignore = "Flaky backend"]
     async fn all() -> DebugResult<()> {
         let resend = &*CLIENT;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,9 +125,8 @@ pub mod types {
     pub use super::domains::types::{
         CreateDomainOptions, DkimRecordType, Domain, DomainCapabilities, DomainCapabilityStatus,
         DomainChanges, DomainDkimRecord, DomainId, DomainRecord, DomainRecordStatus,
-        DomainSpfRecord, DomainStatus,
-        ProxyStatus, ReceivingRecord, ReceivingRecordType, Region, SpfRecordType, Tls,
-        UpdateDomainResponse, VerifyDomainResponse,
+        DomainSpfRecord, DomainStatus, ProxyStatus, ReceivingRecord, ReceivingRecordType, Region,
+        SpfRecordType, Tls, UpdateDomainResponse, VerifyDomainResponse,
     };
     pub use super::emails::types::{
         Attachment, CancelScheduleResponse, ContentDisposition, ContentOrPath, CreateAttachment,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,8 @@ pub mod types {
     };
     pub use super::domains::types::{
         CreateDomainOptions, DkimRecordType, Domain, DomainCapabilities, DomainCapabilityStatus,
-        DomainChanges, DomainDkimRecord, DomainId, DomainRecord, DomainSpfRecord, DomainStatus,
+        DomainChanges, DomainDkimRecord, DomainId, DomainRecord, DomainRecordStatus,
+        DomainSpfRecord, DomainStatus,
         ProxyStatus, ReceivingRecord, ReceivingRecordType, Region, SpfRecordType, Tls,
         UpdateDomainResponse, VerifyDomainResponse,
     };


### PR DESCRIPTION
## Summary

Add two new domain-level statuses — `partially_verified` and `partially_failed` — and split the status typing so they apply only to domains, not individual DNS records.

- `DomainStatus` (domain-level): `pending | verified | failed | not_started | partially_verified | partially_failed`
- `DomainRecordStatus` (record-level, new): `pending | verified | failed | temporary_failure | not_started`

Record status fields on `DomainSpfRecord`, `DomainDkimRecord`, `ReceivingRecord`, `TrackingRecord`, and `TrackingCaaRecord` now use `DomainRecordStatus`. `temporary_failure` remains a record-only value.

Adds two deserialization tests covering `partially_verified` and `partially_failed` domain responses.

Matches resend/resend-node#936.

## Breaking change note

`DomainStatus::TemporaryFailure` has been removed. Consumers pattern-matching on domain status no longer need to handle it (the API never emitted it for domains). Code matching on record-level status should switch to `DomainRecordStatus`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add domain statuses `partially_verified` and `partially_failed`, and split statuses so domains use `DomainStatus` and DNS records use `DomainRecordStatus`. Released in `0.25.0` with new deserialization tests and the domain integration test enabled.

- **Migration**
  - Update record status types to `DomainRecordStatus` on `DomainSpfRecord`, `DomainDkimRecord`, `ReceivingRecord`, `TrackingRecord`, and `TrackingCaaRecord`.
  - Remove `TemporaryFailure` handling from domain-level matches; it now exists only in `DomainRecordStatus`.
  - Import/use `DomainRecordStatus` from the crate re-exports.

- **Dependencies**
  - Bump `rand` to `0.10.1` and `getrandom` to `0.4.2`.

<sup>Written for commit 8f4a1cf85a9079cb6a692c2b2075a12da9b6e934. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

