### PR TITLE
fix(batch): forward Idempotency-Key header in BatchSvc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 <!--## Unreleased-->
 
+## [0.25.1] - 2026-04-29
+
+### Fixed 
+
+- Batch emails no longer ignore the Idempotency-Key header (https://github.com/resend/resend-rust/pull/54)
+
 ## [0.25.0] - 2026-04-20
 
 ### Added
@@ -512,6 +518,7 @@ Disabled `reqwest`'s default features and enabled `rustls-tls`.
 
 Initial release.
 
+[0.25.1]: https://crates.io/crates/resend-rs/0.25.1
 [0.25.0]: https://crates.io/crates/resend-rs/0.25.0
 [0.24.0]: https://crates.io/crates/resend-rs/0.24.0
 [0.23.0]: https://crates.io/crates/resend-rs/0.23.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "resend-rs"
-version = "0.25.0"
+version = "0.25.1"
 edition = "2024"
 
 license = "MIT"

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -47,11 +47,15 @@ impl BatchSvc {
     {
         let emails: Idempotent<T> = emails.into();
 
-        let emails: Vec<_> = emails.data.into_iter().collect();
-
         let mut request = self.0.build(Method::POST, "/emails/batch");
 
         request = request.header("x-batch-validation", batch_validation.to_string());
+
+        if let Some(ref idempotency_key) = emails.idempotency_key {
+            request = request.header("Idempotency-Key", idempotency_key);
+        }
+
+        let emails: Vec<_> = emails.data.into_iter().collect();
 
         let response = self.0.send(request.json(&emails)).await?;
         let content = response.json::<SendEmailBatchPermissiveResponse>().await?;


### PR DESCRIPTION
## Summary

`BatchSvc::send` / `BatchSvc::send_with_batch_validation` accept `impl Into<Idempotent<T>>`, but the `idempotency_key` was silently dropped when the wrapper was unwrapped — only `.data` was extracted, and the `Idempotency-Key` header was never set on the outbound request. Users who attached an idempotency key to a batch retry got zero deduplication, with no error or warning.

## Fix

Mirror the `EmailsSvc::send` pattern in `emails.rs`: borrow the key off the wrapper with `if let Some(ref idempotency_key) = ...` and attach it as a header before consuming `data`.

## References

- Resend API supports idempotency keys on `POST /emails/batch`:
  - https://resend.com/docs/dashboard/emails/idempotency-keys
  - https://resend.com/changelog/batch-idempotency-keys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped idempotency keys in `BatchSvc` for `POST /emails/batch` by forwarding the key from `Idempotent<T>` as the `Idempotency-Key` header before consuming `data`, matching `EmailsSvc::send`, so batch retries deduplicate correctly. Also bumps `resend-rs` to `0.25.1` and updates the changelog.

<sup>Written for commit 41bc6f651c9287be7c202659d46275dd3218a094. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-rust/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

