### PR TITLE
chore: GH Actions hardening — pin actions to SHA, add permissions and timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci/${{ github.ref }}
   cancel-in-progress: true
@@ -16,19 +19,20 @@ concurrency:
 jobs:
   x86_64-unknown-linux-gnu:
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-unknown-linux-gnu
 
       - name: Use cached dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: "ubuntu-24.04-x86_64-unknown-linux-gnu"
+          key: "ubuntu-24.04-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}"
 
       - name: Build
         run: cargo build --verbose
@@ -41,19 +45,20 @@ jobs:
   aarch64-unknown-linux-gnu:
     needs: [x86_64-unknown-linux-gnu]
     runs-on: ubuntu-24.04
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: aarch64-unknown-linux-gnu
 
       - name: Use cached dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: "ubuntu-24.04-aarch64-unknown-linux-gnu"
+          key: "ubuntu-24.04-aarch64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}"
 
       - name: Build
         run: cargo build --verbose
@@ -66,19 +71,20 @@ jobs:
   x86_64-apple-darwin:
     needs: [aarch64-unknown-linux-gnu, x86_64-unknown-linux-gnu]
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-apple-darwin
 
       - name: Use cached dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: "macos-15-x86_64-apple-darwin"
+          key: "macos-15-x86_64-apple-darwin-${{ hashFiles('**/Cargo.lock') }}"
 
       - name: Build
         run: cargo build --verbose
@@ -92,19 +98,20 @@ jobs:
     needs:
       [aarch64-unknown-linux-gnu, x86_64-unknown-linux-gnu, x86_64-apple-darwin]
     runs-on: macos-15
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-pc-windows-msvc
 
       - name: Use cached dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: "windows-2022-x86_64-pc-windows-msvc"
+          key: "windows-2022-x86_64-pc-windows-msvc-${{ hashFiles('**/Cargo.lock') }}"
 
       - name: Build
         run: cargo build --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -48,7 +48,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -101,7 +101,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Use cached dependencies
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 concurrency:
   group: lint/${{ github.ref }}
   cancel-in-progress: true
@@ -17,15 +20,16 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
 
       - name: Use cached dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: "ubuntu-22.04-x86_64-unknown-linux-gnu"
+          key: "ubuntu-22.04-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}"
 
       - name: Install clippy and rustfmt
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     environment: release
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,11 +5,18 @@ on:
     tags:
       - "v*.*.*"
 
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-24.04
-    permissions:
-      contents: write
+    timeout-minutes: 20
+    environment: release
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -17,7 +24,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use cached dependencies
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
 
       - name: Check semver
         run: |
@@ -34,6 +41,6 @@ jobs:
         run: cargo release publish --execute --no-confirm --allow-branch HEAD
 
       - name: GitHub Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3
         with:
           body: Check the [Changelog](https://github.com/resend/resend-rust/blob/main/CHANGELOG.md)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardens GitHub Actions by pinning all third‑party actions to commit SHAs and enforcing least‑privilege, safer caching, and release safeguards. Covers DEV-665 high/medium/low items for `resend-rust`.

- **Refactors**
  - Pinned `actions/checkout`, `dtolnay/rust-toolchain`, `Swatinem/rust-cache`, and `softprops/action-gh-release` to SHAs across `ci`, `lint`, and `publish`.
  - Added top‑level `permissions`: `contents: read` for `ci`/`lint`, `contents: write` for `publish`.
  - Added timeouts: CI jobs 30m, Lint 15m, Publish 20m.
  - Scoped `Swatinem/rust-cache` keys with `${{ hashFiles('**/Cargo.lock') }}`.
  - Hardened `publish`: added `concurrency` group and `environment: release` to enable reviewer gates.

<sup>Written for commit a32f437202647218ffa43258ef1eac38918d4042. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

