### PR TITLE
fix(emails): add topic_id field to CreateEmailBaseOptions struct (#63)

### DIFF
--- a/src/emails.rs
+++ b/src/emails.rs
@@ -149,7 +149,11 @@ pub mod types {
 
     use serde::{Deserialize, Serialize};
 
-    use crate::{emails::parse_nullable_vec, idempotent::Idempotent, types::TemplateId};
+    use crate::{
+        emails::parse_nullable_vec,
+        idempotent::Idempotent,
+        types::{TemplateId, TopicId},
+    };
 
     crate::define_id_type!(EmailId);
     crate::define_id_type!(AttachmentId);
@@ -198,8 +202,12 @@ pub mod types {
         /// Email tags.
         #[serde(skip_serializing_if = "Option::is_none")]
         tags: Option<Vec<Tag>>,
+        /// The template to use for the email.
         #[serde(skip_serializing_if = "Option::is_none")]
         template: Option<EmailTemplate>,
+        /// The topic ID to receive the email.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        topic_id: Option<TopicId>,
 
         /// Schedule email to be sent later. The date should be in ISO 8601 format
         /// (e.g: `2024-08-05T11:52:01.858Z`).
@@ -235,6 +243,7 @@ pub mod types {
                 attachments: None,
                 tags: None,
                 template: None,
+                topic_id: None,
                 scheduled_at: None,
             }
         }
@@ -325,9 +334,17 @@ pub mod types {
             self
         }
 
+        /// Adds the template to use for the email.
         #[inline]
         pub fn with_template(mut self, template: impl Into<EmailTemplate>) -> Self {
             self.template = Some(template.into());
+            self
+        }
+
+        /// Sets the topic ID to receive the email.
+        #[inline]
+        pub fn with_topic(mut self, topic_id: &str) -> Self {
+            self.topic_id = Some(TopicId::new(topic_id));
             self
         }
 


### PR DESCRIPTION
This PR fixes #63.

Simple fix for missing struct field. Enables use case for sending welcome emails with unsubscribe url as described in the issue.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the missing `topic_id` to `CreateEmailBaseOptions` and a `with_topic` builder to target a specific topic. Fixes #63 and enables sending welcome emails with an unsubscribe URL.

- **Bug Fixes**
  - Add `topic_id: Option<TopicId>` to `CreateEmailBaseOptions` (defaults to None, skipped during serialization).
  - Add `with_topic(&str)` builder and import `TopicId`.

<sup>Written for commit b2869ee4a36b16dc0b2dad449fe4f40c5e3db458. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/64?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

