### PR TITLE
fix(contacts): add properties, segments and topics to CreateContactOptions struct

### DIFF
--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -461,6 +461,9 @@ pub mod types {
         pub unsubscribed: bool,
         /// Timestamp indicating when the contact was created in ISO8601 format.
         pub created_at: String,
+        /// Custom properties for the contact.
+        #[serde(default)]
+        properties: Option<HashMap<String, ContactPropertyResponse>>,
     }
 
     /// List of changes to apply to a [`Contact`].
@@ -618,6 +621,13 @@ pub mod types {
         pub fallback_value: Option<serde_json::Value>,
     }
 
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ContactPropertyResponse {
+        pub value: String,
+        #[serde(rename = "type")]
+        pub r#type: PropertyType,
+    }
+
     /// List of changes to apply to a [`ContactProperty`].
     #[must_use]
     #[derive(Debug, Default, Clone, Serialize)]
@@ -654,12 +664,12 @@ pub mod types {
 mod test {
     use std::collections::HashMap;
 
-    use crate::list_opts::ListOptions;
     use crate::test::{CLIENT, DebugResult};
     use crate::types::{
         ContactChanges, ContactProperty, CreateContactOptions, CreateTopicOptions,
         SubscriptionType, UpdateContactTopicOptions,
     };
+    use crate::{list_opts::ListOptions, types::Contact};
 
     #[tokio_shared_rt::test(shared = true)]
     #[cfg(not(feature = "blocking"))]
@@ -776,6 +786,38 @@ mod test {
         Ok(())
     }
 
+    #[tokio_shared_rt::test(shared = true)]
+    #[cfg(not(feature = "blocking"))]
+    async fn tmp() -> DebugResult<()> {
+        use crate::types::CreateContactPropertyOptions;
+
+        let resend = &*CLIENT;
+
+        let contact_property =
+            CreateContactPropertyOptions::new("key", crate::types::PropertyType::String);
+        let contact_property = resend.contacts.create_property(contact_property).await?;
+
+        let contact = CreateContactOptions::new("steve.wozniak@gmail.com")
+            .with_first_name("Steve")
+            .with_last_name("Wozniak")
+            .with_unsubscribed(false)
+            .with_property("key", "value");
+
+        let contact = resend.contacts.create(contact).await?;
+
+        let contact = resend.contacts.get(&contact).await?;
+
+        let deleted = resend.contacts.delete(&contact.id).await?;
+        assert!(deleted);
+        let deleted = resend
+            .contacts
+            .delete_property(&contact_property.id)
+            .await?;
+        assert!(deleted.deleted);
+
+        Ok(())
+    }
+
     #[ignore = "Flaky backend"]
     #[tokio_shared_rt::test(shared = true)]
     #[cfg(not(feature = "blocking"))]
@@ -881,6 +923,28 @@ mod test {
 }"#;
 
         let res = serde_json::from_str::<ContactProperty>(contact_property);
+        assert!(res.is_ok());
+    }
+
+    #[test]
+    fn deserialize_test2() {
+        let contact_property = r#"{
+          "object": "contact",
+          "id": "257d6d3b-e796-464d-ba7d-8ccabc58d16d",
+          "email": "steve.wozniak@gmail.com",
+          "first_name": "Steve",
+          "last_name": "Wozniak",
+          "created_at": "2025-07-21 23:58:57.096708+00",
+          "unsubscribed": false,
+          "properties": {
+            "key": {
+              "value": "value",
+              "type": "string"
+            }
+          }
+        }"#;
+
+        let res = serde_json::from_str::<Contact>(contact_property);
         assert!(res.is_ok());
     }
 

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -312,12 +312,6 @@ pub mod types {
     crate::define_id_type!(ContactId);
     crate::define_id_type!(ContactPropertyId);
 
-    /// A segment reference for adding a contact to a segment during creation.
-    #[derive(Debug, Clone, Serialize)]
-    struct ContactSegmentRef {
-        id: String,
-    }
-
     /// A custom property key-value pair for contact properties.
     ///
     /// # Note
@@ -364,7 +358,7 @@ pub mod types {
         properties: Option<Vec<CreateContactPropertyValue>>,
         /// Segment IDs to add the contact to.
         #[serde(skip_serializing_if = "Option::is_none")]
-        segments: Option<Vec<ContactSegmentRef>>,
+        segments: Option<Vec<String>>,
         /// Topic subscriptions for the contact.
         #[serde(skip_serializing_if = "Option::is_none")]
         topics: Option<Vec<UpdateContactTopicOptions>>,
@@ -433,9 +427,8 @@ pub mod types {
         /// Adds a segment ID to add the contact to.
         #[inline]
         pub fn with_segment(mut self, id: impl Into<String>) -> Self {
-            let segment = ContactSegmentRef { id: id.into() };
             let segments = self.segments.get_or_insert_with(Vec::new);
-            segments.push(segment);
+            segments.push(id.into());
             self
         }
 
@@ -444,7 +437,7 @@ pub mod types {
         pub fn with_segments(mut self, ids: &[String]) -> Self {
             let segments = self.segments.get_or_insert_with(Vec::new);
             for id in ids {
-                segments.push(ContactSegmentRef { id: id.clone() });
+                segments.push(id.clone());
             }
             self
         }

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -395,10 +395,11 @@ pub mod types {
             self
         }
 
-        /// Sets the properties to the passed argument
+        /// Adds custom properties to the contact.
         #[inline]
         pub fn with_properties(mut self, properties: HashMap<String, String>) -> Self {
-            self.properties = Some(properties);
+            let self_properties = self.properties.get_or_insert_with(HashMap::new);
+            self_properties.extend(properties);
             self
         }
 

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -905,6 +905,7 @@ mod test {
     }
 
     #[test]
+    #[allow(clippy::indexing_slicing)]
     fn serialize_create_contact_with_extras() {
         use crate::types::{
             CreateContactPropertyValue, SubscriptionType, UpdateContactTopicOptions,

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -312,6 +312,34 @@ pub mod types {
     crate::define_id_type!(ContactId);
     crate::define_id_type!(ContactPropertyId);
 
+    /// A segment reference for adding a contact to a segment during creation.
+    #[derive(Debug, Clone, Serialize)]
+    struct ContactSegmentRef {
+        id: String,
+    }
+
+    /// A custom property key-value pair for contact properties.
+    ///
+    /// # Note
+    /// The Resend API currently only accepts string values for contact properties.
+    /// Non-string values (numbers, booleans, etc.) will be rejected with a validation error.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct CreateContactPropertyValue {
+        key: String,
+        /// String value for the property. Must be a string; the API does not accept other types.
+        value: String,
+    }
+
+    impl CreateContactPropertyValue {
+        /// Creates a new contact property with a key and string value.
+        pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
+            Self {
+                key: key.into(),
+                value: value.into(),
+            }
+        }
+    }
+
     /// Details of a new [`Contact`].
     #[must_use]
     #[derive(Debug, Clone, Serialize)]
@@ -331,6 +359,15 @@ pub mod types {
         /// Indicates if the contact is unsubscribed.
         #[serde(skip_serializing_if = "Option::is_none")]
         unsubscribed: Option<bool>,
+        /// Custom properties for the contact.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        properties: Option<Vec<CreateContactPropertyValue>>,
+        /// Segment IDs to add the contact to.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        segments: Option<Vec<ContactSegmentRef>>,
+        /// Topic subscriptions for the contact.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        topics: Option<Vec<UpdateContactTopicOptions>>,
     }
 
     impl CreateContactOptions {
@@ -342,6 +379,9 @@ pub mod types {
                 first_name: None,
                 last_name: None,
                 unsubscribed: None,
+                properties: None,
+                segments: None,
+                topics: None,
             }
         }
 
@@ -370,6 +410,64 @@ pub mod types {
         #[inline]
         pub const fn with_unsubscribed(mut self, unsubscribed: bool) -> Self {
             self.unsubscribed = Some(unsubscribed);
+            self
+        }
+
+        /// Adds a custom property to the contact.
+        #[inline]
+        pub fn with_property(mut self, key: &str, value: impl Into<String>) -> Self {
+            let property = CreateContactPropertyValue::new(key, value.into());
+            let properties = self.properties.get_or_insert_with(Vec::new);
+            properties.push(property);
+            self
+        }
+
+        /// Adds multiple custom properties to the contact.
+        #[inline]
+        pub fn with_properties(mut self, properties: &[CreateContactPropertyValue]) -> Self {
+            let properties_vec = self.properties.get_or_insert_with(Vec::new);
+            properties_vec.extend_from_slice(properties);
+            self
+        }
+
+        /// Adds a segment ID to add the contact to.
+        #[inline]
+        pub fn with_segment(mut self, id: impl Into<String>) -> Self {
+            let segment = ContactSegmentRef {
+                id: id.into(),
+            };
+            let segments = self.segments.get_or_insert_with(Vec::new);
+            segments.push(segment);
+            self
+        }
+
+        /// Adds multiple segment IDs to add the contact to.
+        #[inline]
+        pub fn with_segments(mut self, ids: &[String]) -> Self {
+            let segments = self.segments.get_or_insert_with(Vec::new);
+            for id in ids {
+                segments.push(ContactSegmentRef {
+                    id: id.clone(),
+                });
+            }
+            self
+        }
+
+        /// Adds a topic subscription for the contact.
+        #[inline]
+        #[allow(clippy::needless_pass_by_value)]
+        pub fn with_topic(mut self, topic: UpdateContactTopicOptions) -> Self {
+            let topics = self.topics.get_or_insert_with(Vec::new);
+            topics.push(topic);
+            self
+        }
+
+        /// Adds multiple topic subscriptions for the contact.
+        #[inline]
+        #[allow(clippy::needless_pass_by_value)]
+        pub fn with_topics(mut self, topics: &[UpdateContactTopicOptions]) -> Self {
+            let topics_vec = self.topics.get_or_insert_with(Vec::new);
+            topics_vec.extend_from_slice(topics);
             self
         }
     }
@@ -815,5 +913,55 @@ mod test {
 
         let res = serde_json::from_str::<ContactProperty>(contact_property);
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn serialize_create_contact_with_extras() {
+        use crate::types::{CreateContactPropertyValue, SubscriptionType, UpdateContactTopicOptions};
+
+        let topic = UpdateContactTopicOptions::new("topic_123", SubscriptionType::OptIn);
+        let property = CreateContactPropertyValue::new("company", "Acme Corp");
+
+        let contact = CreateContactOptions::new("test@example.com")
+            .with_first_name("John")
+            .with_last_name("Doe")
+            .with_property("department", "Sales")
+            .with_properties(&[property])
+            .with_segment("segment_123")
+            .with_segments(&["segment_456".to_string()])
+            .with_topic(topic)
+            .with_topics(&[UpdateContactTopicOptions::new("topic_789", SubscriptionType::OptOut)]);
+
+        let json = serde_json::to_value(&contact).expect("Failed to serialize");
+
+        // Verify structure
+        assert_eq!(json["email"], "test@example.com");
+        assert_eq!(json["first_name"], "John");
+        assert_eq!(json["last_name"], "Doe");
+
+        // Verify properties
+        assert!(json["properties"].is_array());
+        let properties = json["properties"].as_array().expect("properties should be an array");
+        assert_eq!(properties.len(), 2);
+        assert_eq!(properties[0]["key"], "department");
+        assert_eq!(properties[0]["value"], "Sales");
+        assert_eq!(properties[1]["key"], "company");
+        assert_eq!(properties[1]["value"], "Acme Corp");
+
+        // Verify segments
+        assert!(json["segments"].is_array());
+        let segments = json["segments"].as_array().expect("segments should be an array");
+        assert_eq!(segments.len(), 2);
+        assert_eq!(segments[0]["id"], "segment_123");
+        assert_eq!(segments[1]["id"], "segment_456");
+
+        // Verify topics
+        assert!(json["topics"].is_array());
+        let topics = json["topics"].as_array().expect("topics should be an array");
+        assert_eq!(topics.len(), 2);
+        assert_eq!(topics[0]["id"], "topic_123");
+        assert_eq!(topics[0]["subscription"], "opt_in");
+        assert_eq!(topics[1]["id"], "topic_789");
+        assert_eq!(topics[1]["subscription"], "opt_out");
     }
 }

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -433,9 +433,7 @@ pub mod types {
         /// Adds a segment ID to add the contact to.
         #[inline]
         pub fn with_segment(mut self, id: impl Into<String>) -> Self {
-            let segment = ContactSegmentRef {
-                id: id.into(),
-            };
+            let segment = ContactSegmentRef { id: id.into() };
             let segments = self.segments.get_or_insert_with(Vec::new);
             segments.push(segment);
             self
@@ -446,9 +444,7 @@ pub mod types {
         pub fn with_segments(mut self, ids: &[String]) -> Self {
             let segments = self.segments.get_or_insert_with(Vec::new);
             for id in ids {
-                segments.push(ContactSegmentRef {
-                    id: id.clone(),
-                });
+                segments.push(ContactSegmentRef { id: id.clone() });
             }
             self
         }
@@ -917,7 +913,9 @@ mod test {
 
     #[test]
     fn serialize_create_contact_with_extras() {
-        use crate::types::{CreateContactPropertyValue, SubscriptionType, UpdateContactTopicOptions};
+        use crate::types::{
+            CreateContactPropertyValue, SubscriptionType, UpdateContactTopicOptions,
+        };
 
         let topic = UpdateContactTopicOptions::new("topic_123", SubscriptionType::OptIn);
         let property = CreateContactPropertyValue::new("company", "Acme Corp");
@@ -930,7 +928,10 @@ mod test {
             .with_segment("segment_123")
             .with_segments(&["segment_456".to_string()])
             .with_topic(topic)
-            .with_topics(&[UpdateContactTopicOptions::new("topic_789", SubscriptionType::OptOut)]);
+            .with_topics(&[UpdateContactTopicOptions::new(
+                "topic_789",
+                SubscriptionType::OptOut,
+            )]);
 
         let json = serde_json::to_value(&contact).expect("Failed to serialize");
 
@@ -941,7 +942,9 @@ mod test {
 
         // Verify properties
         assert!(json["properties"].is_array());
-        let properties = json["properties"].as_array().expect("properties should be an array");
+        let properties = json["properties"]
+            .as_array()
+            .expect("properties should be an array");
         assert_eq!(properties.len(), 2);
         assert_eq!(properties[0]["key"], "department");
         assert_eq!(properties[0]["value"], "Sales");
@@ -950,14 +953,18 @@ mod test {
 
         // Verify segments
         assert!(json["segments"].is_array());
-        let segments = json["segments"].as_array().expect("segments should be an array");
+        let segments = json["segments"]
+            .as_array()
+            .expect("segments should be an array");
         assert_eq!(segments.len(), 2);
         assert_eq!(segments[0]["id"], "segment_123");
         assert_eq!(segments[1]["id"], "segment_456");
 
         // Verify topics
         assert!(json["topics"].is_array());
-        let topics = json["topics"].as_array().expect("topics should be an array");
+        let topics = json["topics"]
+            .as_array()
+            .expect("topics should be an array");
         assert_eq!(topics.len(), 2);
         assert_eq!(topics[0]["id"], "topic_123");
         assert_eq!(topics[0]["subscription"], "opt_in");

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -787,9 +787,10 @@ mod test {
         Ok(())
     }
 
+    #[ignore = "Flaky backend"]
     #[tokio_shared_rt::test(shared = true)]
     #[cfg(not(feature = "blocking"))]
-    async fn tmp() -> DebugResult<()> {
+    async fn contact_properties() -> DebugResult<()> {
         use crate::types::CreateContactPropertyOptions;
 
         let resend = &*CLIENT;
@@ -819,9 +820,9 @@ mod test {
         Ok(())
     }
 
-    #[ignore = "Flaky backend"]
     #[tokio_shared_rt::test(shared = true)]
     #[cfg(not(feature = "blocking"))]
+    #[ignore = "Flaky backend"]
     async fn segments() -> DebugResult<()> {
         let resend = &*CLIENT;
 
@@ -979,15 +980,20 @@ mod test {
         assert_eq!(json["last_name"], "Doe");
 
         // Verify properties
-        assert!(json["properties"].is_array());
+        assert!(json["properties"].is_object());
         let properties = json["properties"]
-            .as_array()
-            .expect("properties should be an array");
+            .as_object()
+            .expect("properties should be a map");
         assert_eq!(properties.len(), 2);
-        assert_eq!(properties[0]["key"], "department");
-        assert_eq!(properties[0]["value"], "Sales");
-        assert_eq!(properties[1]["key"], "company");
-        assert_eq!(properties[1]["value"], "Acme Corp");
+        assert!(properties.contains_key("department"));
+        assert_eq!(
+            properties.get("department"),
+            Some(serde_json::Value::String("Sales".to_owned())).as_ref()
+        );
+        assert_eq!(
+            properties.get("company"),
+            Some(serde_json::Value::String("Acme Corp".to_owned())).as_ref()
+        );
 
         // Verify segments
         assert!(json["segments"].is_array());
@@ -995,8 +1001,14 @@ mod test {
             .as_array()
             .expect("segments should be an array");
         assert_eq!(segments.len(), 2);
-        assert_eq!(segments[0]["id"], "segment_123");
-        assert_eq!(segments[1]["id"], "segment_456");
+        assert_eq!(
+            segments[0],
+            serde_json::Value::String("segment_123".to_owned())
+        );
+        assert_eq!(
+            segments[1],
+            serde_json::Value::String("segment_456".to_owned())
+        );
 
         // Verify topics
         assert!(json["topics"].is_array());

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -302,6 +302,8 @@ impl fmt::Debug for ContactsSvc {
 
 #[allow(unreachable_pub)]
 pub mod types {
+    use std::collections::HashMap;
+
     use serde::{Deserialize, Serialize};
 
     use crate::{
@@ -311,28 +313,6 @@ pub mod types {
 
     crate::define_id_type!(ContactId);
     crate::define_id_type!(ContactPropertyId);
-
-    /// A custom property key-value pair for contact properties.
-    ///
-    /// # Note
-    /// The Resend API currently only accepts string values for contact properties.
-    /// Non-string values (numbers, booleans, etc.) will be rejected with a validation error.
-    #[derive(Debug, Clone, Serialize)]
-    pub struct CreateContactPropertyValue {
-        key: String,
-        /// String value for the property. Must be a string; the API does not accept other types.
-        value: String,
-    }
-
-    impl CreateContactPropertyValue {
-        /// Creates a new contact property with a key and string value.
-        pub fn new(key: impl Into<String>, value: impl Into<String>) -> Self {
-            Self {
-                key: key.into(),
-                value: value.into(),
-            }
-        }
-    }
 
     /// Details of a new [`Contact`].
     #[must_use]
@@ -355,7 +335,7 @@ pub mod types {
         unsubscribed: Option<bool>,
         /// Custom properties for the contact.
         #[serde(skip_serializing_if = "Option::is_none")]
-        properties: Option<Vec<CreateContactPropertyValue>>,
+        properties: Option<HashMap<String, String>>,
         /// Segment IDs to add the contact to.
         #[serde(skip_serializing_if = "Option::is_none")]
         segments: Option<Vec<String>>,
@@ -409,18 +389,16 @@ pub mod types {
 
         /// Adds a custom property to the contact.
         #[inline]
-        pub fn with_property(mut self, key: &str, value: impl Into<String>) -> Self {
-            let property = CreateContactPropertyValue::new(key, value.into());
-            let properties = self.properties.get_or_insert_with(Vec::new);
-            properties.push(property);
+        pub fn with_property(mut self, key: &str, value: &str) -> Self {
+            let properties = self.properties.get_or_insert_with(HashMap::new);
+            let _old = properties.insert(key.to_owned(), value.to_owned());
             self
         }
 
-        /// Adds multiple custom properties to the contact.
+        /// Sets the properties to the passed argument
         #[inline]
-        pub fn with_properties(mut self, properties: &[CreateContactPropertyValue]) -> Self {
-            let properties_vec = self.properties.get_or_insert_with(Vec::new);
-            properties_vec.extend_from_slice(properties);
+        pub fn with_properties(mut self, properties: HashMap<String, String>) -> Self {
+            self.properties = Some(properties);
             self
         }
 
@@ -674,6 +652,8 @@ pub mod types {
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::needless_return)]
 mod test {
+    use std::collections::HashMap;
+
     use crate::list_opts::ListOptions;
     use crate::test::{CLIENT, DebugResult};
     use crate::types::{
@@ -907,18 +887,17 @@ mod test {
     #[test]
     #[allow(clippy::indexing_slicing)]
     fn serialize_create_contact_with_extras() {
-        use crate::types::{
-            CreateContactPropertyValue, SubscriptionType, UpdateContactTopicOptions,
-        };
+        use crate::types::{SubscriptionType, UpdateContactTopicOptions};
 
         let topic = UpdateContactTopicOptions::new("topic_123", SubscriptionType::OptIn);
-        let property = CreateContactPropertyValue::new("company", "Acme Corp");
+        let mut properties = HashMap::new();
+        let _old = properties.insert("company".to_owned(), "Acme Corp".to_owned());
 
         let contact = CreateContactOptions::new("test@example.com")
             .with_first_name("John")
             .with_last_name("Doe")
             .with_property("department", "Sales")
-            .with_properties(&[property])
+            .with_properties(properties)
             .with_segment("segment_123")
             .with_segments(&["segment_456".to_string()])
             .with_topic(topic)

--- a/src/emails.rs
+++ b/src/emails.rs
@@ -648,9 +648,10 @@ pub mod types {
             self
         }
 
-        /// Sets the variables to the passed argument
+        /// Adds variables
         pub fn with_variables(mut self, variables: HashMap<String, serde_json::Value>) -> Self {
-            self.variables = Some(variables);
+            let self_variables = self.variables.get_or_insert_with(HashMap::new);
+            self_variables.extend(variables);
             self
         }
     }

--- a/src/emails.rs
+++ b/src/emails.rs
@@ -641,6 +641,14 @@ pub mod types {
             }
         }
 
+        /// Adds a variable
+        pub fn with_variable(mut self, key: &str, value: serde_json::Value) -> Self {
+            let variables = self.variables.get_or_insert_with(HashMap::new);
+            let _old = variables.insert(key.to_owned(), value);
+            self
+        }
+
+        /// Sets the variables to the passed argument
         pub fn with_variables(mut self, variables: HashMap<String, serde_json::Value>) -> Self {
             self.variables = Some(variables);
             self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,9 +118,9 @@ pub mod types {
     pub use super::contacts::types::{
         AddContactSegmentResponse, Contact, ContactChanges, ContactId, ContactProperty,
         ContactPropertyChanges, ContactPropertyId, ContactTopic, CreateContactOptions,
-        CreateContactPropertyOptions, CreateContactPropertyResponse, DeleteContactPropertyResponse,
-        PropertyType, RemoveContactSegmentResponse, UpdateContactPropertyResponse,
-        UpdateContactTopicOptions,
+        CreateContactPropertyOptions, CreateContactPropertyResponse, CreateContactPropertyValue,
+        DeleteContactPropertyResponse, PropertyType, RemoveContactSegmentResponse,
+        UpdateContactPropertyResponse, UpdateContactTopicOptions,
     };
     pub use super::domains::types::{
         CreateDomainOptions, DkimRecordType, Domain, DomainCapabilities, DomainCapabilityStatus,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,9 +118,9 @@ pub mod types {
     pub use super::contacts::types::{
         AddContactSegmentResponse, Contact, ContactChanges, ContactId, ContactProperty,
         ContactPropertyChanges, ContactPropertyId, ContactTopic, CreateContactOptions,
-        CreateContactPropertyOptions, CreateContactPropertyResponse, CreateContactPropertyValue,
-        DeleteContactPropertyResponse, PropertyType, RemoveContactSegmentResponse,
-        UpdateContactPropertyResponse, UpdateContactTopicOptions,
+        CreateContactPropertyOptions, CreateContactPropertyResponse, DeleteContactPropertyResponse,
+        PropertyType, RemoveContactSegmentResponse, UpdateContactPropertyResponse,
+        UpdateContactTopicOptions,
     };
     pub use super::domains::types::{
         CreateDomainOptions, DkimRecordType, Domain, DomainCapabilities, DomainCapabilityStatus,


### PR DESCRIPTION
fixes #68 

adds structure fields, some helper types, builder methods for single and multi-items, and a test case with these extra fields.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for setting contact properties, segments, and topics via `CreateContactOptions`, plus an email `with_variable` helper. Also returns typed contact properties in GET responses. Addresses #68.

- **New Features**
  - `CreateContactOptions` adds `properties: HashMap<String, String>`, `segments: Vec<String>`, and `topics: Vec<UpdateContactTopicOptions>` with builders: `with_property`, `with_properties`, `with_segment`, `with_segments`, `with_topic`, `with_topics`; emails add `with_variable`.

- **Bug Fixes**
  - Plural builders now append instead of overwrite: `with_properties`, `with_segments`, `with_topics`, and emails `with_variables`.

<sup>Written for commit afc863d693a012651b136cc5c248b0de3d4bd91e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/69?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

