### PR TITLE
feat: add received_for to inbound email and received event types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 <!--## Unreleased-->
 
+## [0.27.0] - 2026-06-27
+
+### Added
+
+- add received_for to inbound email and received event types (https://github.com/resend/resend-rust/pull/74)
+
 ## [0.26.1] - 2026-06-18
 
 ### Added
@@ -540,6 +546,7 @@ Disabled `reqwest`'s default features and enabled `rustls-tls`.
 
 Initial release.
 
+[0.27.0]: https://crates.io/crates/resend-rs/0.27.0
 [0.26.1]: https://crates.io/crates/resend-rs/0.26.1
 [0.26.0]: https://crates.io/crates/resend-rs/0.26.0
 [0.25.1]: https://crates.io/crates/resend-rs/0.25.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "resend-rs"
-version = "0.26.1"
+version = "0.27.0"
 edition = "2024"
 
 license = "MIT"
@@ -37,12 +37,12 @@ thiserror = { version = "2.0" }
 maybe-async = { version = "0.2.11" }
 governor = "0.10.4"
 rand = "0.10.1"
-getrandom = { version = "0.4.2", features = ["wasm_js"] }
+getrandom = { version = "0.4.3", features = ["wasm_js"] }
 serde_json = "1.0.150"
 mailparse = "0.16.1"
 
 [dev-dependencies]
-jiff = { version = "0.2.28", features = ["serde"] }
+jiff = { version = "0.2.29", features = ["serde"] }
 tokio = { version = "1.52.3", features = [
   "macros",
   "test-util",
@@ -53,7 +53,7 @@ scraper = "0.27.0"
 regex = "1.12.4"
 # Used in examples
 axum = "0.8.9"
-svix = "1.95.2"
+svix = "1.96.1"
 http-body-util = "0.1.3"
 tokio-shared-rt = "0.1.0"
 anyhow = "1.0"

--- a/src/events.rs
+++ b/src/events.rs
@@ -376,6 +376,8 @@ pub struct Suppressed {
 pub struct Received {
     pub bcc: Vec<String>,
     pub cc: Vec<String>,
+    #[serde(default)]
+    pub received_for: Vec<String>,
     pub message_id: String,
     pub attachments: Vec<InboundAttachment>,
 }
@@ -797,6 +799,7 @@ mod test {
         "to": ["delivered@resend.dev"],
         "bcc": [],
         "cc": [],
+        "received_for": ["forwarded@example.com"],
         "message_id": "<example+123>",
         "subject": "Sending this example",
         "attachments": [
@@ -824,6 +827,7 @@ mod test {
             assert!(received.attachments.len() == 1);
             assert!(received.cc.is_empty());
             assert!(received.bcc.is_empty());
+            assert_eq!(received.received_for, vec!["forwarded@example.com"]);
         } else {
             panic!("Wrong parsing");
         }

--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -264,6 +264,8 @@ pub mod types {
         pub cc: Vec<String>,
         #[serde(default)]
         pub reply_to: Vec<String>,
+        #[serde(default)]
+        pub received_for: Vec<String>,
         pub html: Option<String>,
         pub text: Option<String>,
         #[serde(default)]
@@ -445,6 +447,7 @@ mod test {
       "bcc": [],
       "cc": [],
       "reply_to": [],
+      "received_for": ["forwarded@example.com"],
       "message_id": "<111-222-333@email.provider.example.com>",
       "raw": {
         "download_url": "https://example.com/emails/raw/abc123?signature=xyz789",
@@ -466,6 +469,9 @@ mod test {
 
         let res = serde_json::from_str::<ListResponse<InboundEmail>>(emails);
         assert!(res.is_ok());
-        assert!(res.unwrap().data.first().unwrap().raw.is_some());
+        let data = res.unwrap();
+        let email = data.data.first().unwrap();
+        assert!(email.raw.is_some());
+        assert_eq!(email.received_for, vec!["forwarded@example.com"]);
     }
 }


### PR DESCRIPTION
Adds the received_for field to the inbound email and email.received event types, matching the API.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `received_for` field to inbound email and `email.received` event types to match the API, and bump `resend-rs` to `0.27.0`. This tells consumers which address an email was received for, including forwarded cases.

- **New Features**
  - Added `received_for: Vec<String>` with `#[serde(default)]` to `receiving::types::InboundEmail` and `events::Received`.
  - Updated tests to assert parsing of `received_for`.

- **Dependencies**
  - Bumped `getrandom` to `0.4.3`, `jiff` to `0.2.29`, and `svix` to `1.96.1`.

<sup>Written for commit ea4e91d6666ca091d7cd3fae88476cb41f6ebe5c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/74?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

