### PR TITLE
feat: add message_id to Email and webhook EmailBody types

### DIFF
--- a/src/emails.rs
+++ b/src/emails.rs
@@ -541,6 +541,8 @@ pub mod types {
     pub struct Email {
         /// The ID of the email.
         pub id: EmailId,
+        /// RFC Message-ID header value for the email.
+        pub message_id: String,
 
         /// Sender email address.
         pub from: String,
@@ -713,6 +715,7 @@ mod test {
         let email = r#"{
             "object": "email",
             "id": "6757a66c-3a5b-49ee-98cc-fca7a5f423c0",
+            "message_id": "<111-222-333@email.example.com>",
             "to": [
                 "email@gmail.com"
             ],
@@ -731,6 +734,7 @@ mod test {
         let res = serde_json::from_str::<Email>(email);
         assert!(res.is_ok());
         let res = res.unwrap();
+        assert_eq!(res.message_id, "<111-222-333@email.example.com>");
         assert!(res.cc.is_empty());
         assert!(res.bcc.is_empty());
         assert!(res.text.is_none());
@@ -738,6 +742,7 @@ mod test {
         let email = r#"{
             "object": "email",
             "id": "6757a66c-3a5b-49ee-98cc-fca7a5f423c0",
+            "message_id": "<111-222-333@email.example.com>",
             "to": [
                 "email@gmail.com"
             ],

--- a/src/events.rs
+++ b/src/events.rs
@@ -196,6 +196,7 @@ pub mod types {
 ///       "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
 ///       "created_at": "2024-02-22T23:41:11.894719+00:00",
 ///       "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+///       "message_id": "<111-222-333@email.example.com>",
 ///       "from": "Acme <onboarding@resend.dev>",
 ///       "to": ["delivered@resend.dev"],
 ///       "subject": "Sending this example",
@@ -347,6 +348,8 @@ pub struct EmailBody {
     pub broadcast_id: Option<BroadcastId>,
     pub created_at: String,
     pub email_id: EmailId,
+    /// RFC Message-ID header value for the email.
+    pub message_id: String,
     pub from: String,
     pub to: Vec<String>,
     pub subject: String,
@@ -378,7 +381,6 @@ pub struct Received {
     pub cc: Vec<String>,
     #[serde(default)]
     pub received_for: Vec<String>,
-    pub message_id: String,
     pub attachments: Vec<InboundAttachment>,
 }
 
@@ -523,6 +525,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-02-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -539,6 +542,10 @@ mod test {
 
         if let Event::EmailEvent(email_event) = parsed {
             assert!(matches!(email_event.r#type, EmailEventType::EmailSent));
+            assert_eq!(
+                email_event.data.message_id,
+                "<111-222-333@email.example.com>"
+            );
         } else {
             panic!("Wrong parsing");
         }
@@ -554,6 +561,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-02-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -585,6 +593,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-02-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -619,6 +628,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-02-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -653,6 +663,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-11-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -690,6 +701,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-02-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -721,6 +733,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-11-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "click": {
@@ -760,6 +773,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-11-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -820,6 +834,7 @@ mod test {
 
         if let Event::EmailEvent(email_event) = parsed {
             assert!(matches!(email_event.r#type, EmailEventType::EmailReceived));
+            assert_eq!(email_event.data.message_id, "<example+123>");
             assert!(email_event.data.received.is_some());
             assert!(email_event.data.tags.is_empty());
 
@@ -843,6 +858,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-02-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",
@@ -876,6 +892,7 @@ mod test {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
         "created_at": "2024-11-22T23:41:11.894719+00:00",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
+        "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "subject": "Sending this example",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `message_id` typing to match the Resend API and Node.js SDK:

- **`types::Email`** — `message_id` is now deserialized from `GET /emails/:id` and list responses
- **`events::EmailBody`** — `message_id` is now available on all email webhook event payloads (not only `email.received`)

The field was previously only exposed on inbound emails (`InboundEmail`) and nested inside the `Received` webhook struct. It is now a top-level field on `EmailBody`, so consumers can access `event.data.message_id` consistently across all email webhook types.

## Changes

- Added `message_id: String` to `emails::types::Email`
- Added `message_id: String` to `events::EmailBody`
- Removed duplicate `message_id` from `events::Received` (still flattened via `EmailBody`)
- Updated deserialization tests and webhook fixture JSON

## Test plan

- [x] `cargo test --lib --no-default-features --features rustls-tls deserialize`
- [x] `cargo test --lib --no-default-features --features rustls-tls events::test::email_`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0fbb2efd-af95-4bc5-bc79-5dd96de3abdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0fbb2efd-af95-4bc5-bc79-5dd96de3abdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the RFC Message-ID on sent emails and all email webhook events for consistent access across the API. Aligns with the Resend API and Node.js SDK.

- **New Features**
  - `types::Email`: added `message_id` from GET /emails/:id and list responses.
  - `events::EmailBody`: added top-level `message_id` on all email webhook payloads.

- **Migration**
  - `events::Received.message_id` was removed. Use `EmailBody.message_id` instead (e.g., `event.data.message_id`).

<sup>Written for commit e1ab13e889030a0c534b0951928c1437b9891834. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/77?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

