### PR TITLE
feat(batch): reflect tags in batch send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to
 
 ### Added
 
+- batch send support for `scheduled_at`, `tags`, and `attachments` on [`CreateEmailBaseOptions`](https://docs.rs/resend-rs/latest/resend_rs/types/struct.CreateEmailBaseOptions.html)
 - add `message_id` to `Email` and webhook `EmailBody` types (https://github.com/resend/resend-rust/pull/77)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to
 
 ### Added
 
-- batch send support for `scheduled_at`, `tags`, and `attachments` on [`CreateEmailBaseOptions`](https://docs.rs/resend-rs/latest/resend_rs/types/struct.CreateEmailBaseOptions.html)
+- batch send support for `tags` on [`CreateEmailBaseOptions`](https://docs.rs/resend-rs/latest/resend_rs/types/struct.CreateEmailBaseOptions.html)
 - add `message_id` to `Email` and webhook `EmailBody` types (https://github.com/resend/resend-rust/pull/77)
 
 

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -20,6 +20,9 @@ impl BatchSvc {
     /// Instead of sending one email per HTTP request, we provide a batching endpoint
     /// that permits you to send up to 100 emails in a single API call.
     ///
+    /// Each [`CreateEmailBaseOptions`] in the batch supports `scheduled_at`, `tags`,
+    /// and `attachments`, in addition to the other send-email body parameters.
+    ///
     /// <https://resend.com/docs/api-reference/emails/send-batch-emails>
     #[maybe_async::maybe_async]
     pub async fn send<T>(
@@ -122,8 +125,8 @@ pub mod types {
 mod test {
     use crate::test::{CLIENT, DebugResult};
     use crate::types::{
-        BatchValidation, CreateEmailBaseOptions, CreateTemplateOptions, EmailEvent, EmailTemplate,
-        Variable, VariableType,
+        BatchValidation, CreateAttachment, CreateEmailBaseOptions, CreateTemplateOptions,
+        EmailEvent, EmailTemplate, Tag, Variable, VariableType,
     };
 
     #[tokio_shared_rt::test(shared = true)]
@@ -320,6 +323,163 @@ mod test {
         // Delete template
         let deleted = resend.templates.delete(template_id).await?;
         assert!(deleted.deleted);
+
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_schedule_tags_attachments() {
+        use serde_json::json;
+
+        let email = CreateEmailBaseOptions::new(
+            "Acme <onboarding@resend.dev>",
+            ["delivered@resend.dev"],
+            "hello world",
+        )
+        .with_html("<h1>it works!</h1>")
+        .with_tag(Tag::new("category", "confirm_email"))
+        .with_scheduled_at("2025-09-25T11:52:01.858Z")
+        .with_attachment(
+            CreateAttachment::from_content(b"hello".to_vec()).with_filename("test.txt"),
+        );
+
+        let emails = vec![email];
+        let value = serde_json::to_value(&emails).unwrap();
+
+        let email = &value[0];
+        assert_eq!(
+            email["tags"],
+            json!([{"name": "category", "value": "confirm_email"}])
+        );
+        assert_eq!(email["scheduled_at"], json!("2025-09-25T11:52:01.858Z"));
+        assert!(email["attachments"].is_array());
+        assert_eq!(email["attachments"][0]["filename"], "test.txt");
+    }
+
+    #[tokio_shared_rt::test(shared = true)]
+    #[cfg(not(feature = "blocking"))]
+    async fn tags() -> DebugResult<()> {
+        let resend = &*CLIENT;
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let emails = vec![
+            CreateEmailBaseOptions::new(
+                "Acme <onboarding@resend.dev>",
+                ["delivered@resend.dev"],
+                "hello world",
+            )
+            .with_html("<h1>it works!</h1>")
+            .with_tag(Tag::new("category", "confirm_email")),
+            CreateEmailBaseOptions::new(
+                "Acme <onboarding@resend.dev>",
+                ["delivered@resend.dev"],
+                "world hello",
+            )
+            .with_html("<p>it works!</p>")
+            .with_tag(Tag::new("category", "confirm_email")),
+        ];
+
+        let emails = resend.batch.send(emails).await?;
+        assert_eq!(emails.len(), 2);
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared = true)]
+    #[cfg(not(feature = "blocking"))]
+    async fn schedule() -> DebugResult<()> {
+        use jiff::{Span, Timestamp, Zoned};
+
+        let now_plus_1h = Zoned::now()
+            .checked_add(Span::new().hours(1))
+            .expect("Valid date")
+            .timestamp()
+            .to_string();
+
+        let resend = &*CLIENT;
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let emails = vec![
+            CreateEmailBaseOptions::new(
+                "Acme <onboarding@resend.dev>",
+                ["delivered@resend.dev"],
+                "hello world",
+            )
+            .with_html("<h1>it works!</h1>")
+            .with_scheduled_at(&now_plus_1h),
+            CreateEmailBaseOptions::new(
+                "Acme <onboarding@resend.dev>",
+                ["delivered@resend.dev"],
+                "world hello",
+            )
+            .with_html("<p>it works!</p>")
+            .with_scheduled_at(&now_plus_1h),
+        ];
+
+        let emails = resend.batch.send(emails).await?;
+        assert_eq!(emails.len(), 2);
+        std::thread::sleep(std::time::Duration::from_secs(4));
+
+        for email in emails {
+            let email = resend.emails.get(&email.id).await?;
+            assert_eq!(email.last_event, EmailEvent::Scheduled);
+            assert!(email.scheduled_at.is_some());
+            let time = email
+                .scheduled_at
+                .unwrap()
+                .parse::<Timestamp>()
+                .expect("Valid timestamp");
+            let time_delta = (time - Timestamp::now()).round(jiff::Unit::Hour).unwrap();
+            assert_eq!(
+                time_delta.compare(Span::new().hours(1)).unwrap(),
+                std::cmp::Ordering::Equal
+            );
+
+            let _cancelled = resend.emails.cancel(&email.id).await?;
+        }
+
+        Ok(())
+    }
+
+    #[tokio_shared_rt::test(shared = true)]
+    #[cfg(not(feature = "blocking"))]
+    async fn attachments() -> DebugResult<()> {
+        use crate::list_opts::ListOptions;
+
+        let resend = &*CLIENT;
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        let attachment = CreateAttachment::from_content(include_bytes!("../README.md").to_vec())
+            .with_filename("README.md");
+
+        let emails = vec![
+            CreateEmailBaseOptions::new(
+                "Acme <onboarding@resend.dev>",
+                ["delivered@resend.dev"],
+                "hello world",
+            )
+            .with_html("<h1>it works!</h1>")
+            .with_attachment(attachment.clone()),
+            CreateEmailBaseOptions::new(
+                "Acme <onboarding@resend.dev>",
+                ["delivered@resend.dev"],
+                "world hello",
+            )
+            .with_html("<p>it works!</p>")
+            .with_attachment(attachment),
+        ];
+
+        let emails = resend.batch.send(emails).await?;
+        assert_eq!(emails.len(), 2);
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        for email in emails {
+            let attachments = resend
+                .emails
+                .list_attachments(&email.id, ListOptions::default())
+                .await?;
+            assert_eq!(attachments.data.len(), 1);
+        }
 
         Ok(())
     }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -20,8 +20,8 @@ impl BatchSvc {
     /// Instead of sending one email per HTTP request, we provide a batching endpoint
     /// that permits you to send up to 100 emails in a single API call.
     ///
-    /// Each [`CreateEmailBaseOptions`] in the batch supports `scheduled_at`, `tags`,
-    /// and `attachments`, in addition to the other send-email body parameters.
+    /// Each [`CreateEmailBaseOptions`] in the batch supports `tags`, in addition to
+    /// the other send-email body parameters.
     ///
     /// <https://resend.com/docs/api-reference/emails/send-batch-emails>
     #[maybe_async::maybe_async]
@@ -125,8 +125,8 @@ pub mod types {
 mod test {
     use crate::test::{CLIENT, DebugResult};
     use crate::types::{
-        BatchValidation, CreateAttachment, CreateEmailBaseOptions, CreateTemplateOptions,
-        EmailEvent, EmailTemplate, Tag, Variable, VariableType,
+        BatchValidation, CreateEmailBaseOptions, CreateTemplateOptions, EmailEvent, EmailTemplate,
+        Tag, Variable, VariableType,
     };
 
     #[tokio_shared_rt::test(shared = true)]
@@ -328,7 +328,7 @@ mod test {
     }
 
     #[test]
-    fn serialize_schedule_tags_attachments() {
+    fn serialize_tags() {
         use serde_json::json;
 
         let email = CreateEmailBaseOptions::new(
@@ -337,23 +337,15 @@ mod test {
             "hello world",
         )
         .with_html("<h1>it works!</h1>")
-        .with_tag(Tag::new("category", "confirm_email"))
-        .with_scheduled_at("2025-09-25T11:52:01.858Z")
-        .with_attachment(
-            CreateAttachment::from_content(b"hello".to_vec()).with_filename("test.txt"),
-        );
+        .with_tag(Tag::new("category", "confirm_email"));
 
         let emails = vec![email];
         let value = serde_json::to_value(&emails).unwrap();
 
-        let email = &value[0];
         assert_eq!(
-            email["tags"],
+            value[0]["tags"],
             json!([{"name": "category", "value": "confirm_email"}])
         );
-        assert_eq!(email["scheduled_at"], json!("2025-09-25T11:52:01.858Z"));
-        assert!(email["attachments"].is_array());
-        assert_eq!(email["attachments"][0]["filename"], "test.txt");
     }
 
     #[tokio_shared_rt::test(shared = true)]
@@ -381,105 +373,6 @@ mod test {
 
         let emails = resend.batch.send(emails).await?;
         assert_eq!(emails.len(), 2);
-
-        Ok(())
-    }
-
-    #[tokio_shared_rt::test(shared = true)]
-    #[cfg(not(feature = "blocking"))]
-    async fn schedule() -> DebugResult<()> {
-        use jiff::{Span, Timestamp, Zoned};
-
-        let now_plus_1h = Zoned::now()
-            .checked_add(Span::new().hours(1))
-            .expect("Valid date")
-            .timestamp()
-            .to_string();
-
-        let resend = &*CLIENT;
-        std::thread::sleep(std::time::Duration::from_secs(1));
-
-        let emails = vec![
-            CreateEmailBaseOptions::new(
-                "Acme <onboarding@resend.dev>",
-                ["delivered@resend.dev"],
-                "hello world",
-            )
-            .with_html("<h1>it works!</h1>")
-            .with_scheduled_at(&now_plus_1h),
-            CreateEmailBaseOptions::new(
-                "Acme <onboarding@resend.dev>",
-                ["delivered@resend.dev"],
-                "world hello",
-            )
-            .with_html("<p>it works!</p>")
-            .with_scheduled_at(&now_plus_1h),
-        ];
-
-        let emails = resend.batch.send(emails).await?;
-        assert_eq!(emails.len(), 2);
-        std::thread::sleep(std::time::Duration::from_secs(4));
-
-        for email in emails {
-            let email = resend.emails.get(&email.id).await?;
-            assert_eq!(email.last_event, EmailEvent::Scheduled);
-            assert!(email.scheduled_at.is_some());
-            let time = email
-                .scheduled_at
-                .unwrap()
-                .parse::<Timestamp>()
-                .expect("Valid timestamp");
-            let time_delta = (time - Timestamp::now()).round(jiff::Unit::Hour).unwrap();
-            assert_eq!(
-                time_delta.compare(Span::new().hours(1)).unwrap(),
-                std::cmp::Ordering::Equal
-            );
-
-            let _cancelled = resend.emails.cancel(&email.id).await?;
-        }
-
-        Ok(())
-    }
-
-    #[tokio_shared_rt::test(shared = true)]
-    #[cfg(not(feature = "blocking"))]
-    async fn attachments() -> DebugResult<()> {
-        use crate::list_opts::ListOptions;
-
-        let resend = &*CLIENT;
-        std::thread::sleep(std::time::Duration::from_secs(1));
-
-        let attachment = CreateAttachment::from_content(include_bytes!("../README.md").to_vec())
-            .with_filename("README.md");
-
-        let emails = vec![
-            CreateEmailBaseOptions::new(
-                "Acme <onboarding@resend.dev>",
-                ["delivered@resend.dev"],
-                "hello world",
-            )
-            .with_html("<h1>it works!</h1>")
-            .with_attachment(attachment.clone()),
-            CreateEmailBaseOptions::new(
-                "Acme <onboarding@resend.dev>",
-                ["delivered@resend.dev"],
-                "world hello",
-            )
-            .with_html("<p>it works!</p>")
-            .with_attachment(attachment),
-        ];
-
-        let emails = resend.batch.send(emails).await?;
-        assert_eq!(emails.len(), 2);
-        std::thread::sleep(std::time::Duration::from_secs(1));
-
-        for email in emails {
-            let attachments = resend
-                .emails
-                .list_attachments(&email.id, ListOptions::default())
-                .await?;
-            assert_eq!(attachments.data.len(), 1);
-        }
 
         Ok(())
     }

--- a/src/emails.rs
+++ b/src/emails.rs
@@ -160,11 +160,9 @@ pub mod types {
 
     /// All requisite components and associated data to send an email.
     ///
-    /// Used by both the single-send and batch-send endpoints. See [`send_email_docs`]
-    /// and [`batch_email_docs`].
+    /// See [`docs`].
     ///
-    /// [`send_email_docs`]: https://resend.com/docs/api-reference/emails/send-email#body-parameters
-    /// [`batch_email_docs`]: https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
+    /// [`docs`]: https://resend.com/docs/api-reference/emails/send-email#body-parameters
     #[must_use]
     #[derive(Debug, Clone, Serialize)]
     pub struct CreateEmailBaseOptions {

--- a/src/emails.rs
+++ b/src/emails.rs
@@ -160,9 +160,11 @@ pub mod types {
 
     /// All requisite components and associated data to send an email.
     ///
-    /// See [`docs`].
+    /// Used by both the single-send and batch-send endpoints. See [`send_email_docs`]
+    /// and [`batch_email_docs`].
     ///
-    /// [`docs`]: https://resend.com/docs/api-reference/emails/send-email#body-parameters
+    /// [`send_email_docs`]: https://resend.com/docs/api-reference/emails/send-email#body-parameters
+    /// [`batch_email_docs`]: https://resend.com/docs/api-reference/emails/send-batch-emails#body-parameters
     #[must_use]
     #[derive(Debug, Clone, Serialize)]
     pub struct CreateEmailBaseOptions {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The batch send API supports `tags` on each email in the batch. This crate already exposes tags on `CreateEmailBaseOptions`, which batch send uses — this change documents that and adds coverage.

## Changes

- Document batch support for `tags` on `BatchSvc::send`
- Add a serialization unit test asserting the batch payload includes tags
- Add an integration test for batch sends with tags
- Changelog entry under Unreleased
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9ab52f0-136f-4c55-9729-21d092f2c357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9ab52f0-136f-4c55-9729-21d092f2c357"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented and tested batch send support for per-email `tags`. Updated docs to state that batch supports `tags` only and not `attachments` or `scheduled_at`, removing a `CreateEmailBaseOptions` link that implied otherwise.

- Added unit and integration tests to verify tag serialization in batch sends.

<sup>Written for commit bfdb2675a09d0d593bbc7ca3cc4226144d83854c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

