### PR TITLE
test: fix flaky email-state assertions by polling instead of sleeping

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,22 @@ You will notice that some of the tests are slow, there's 2 reasons for this:
 
 1. The tests all use a shared client that implements rate-limiting to avoid getting errors from
    the server
-2. There are some thread sleep statements here and there to make sure that calls that create a
-   resource have been properly processed
+2. Creating a resource is not instant, so tests have to wait for the server to finish processing
+   it before asserting on the result
+
+For the second point, prefer polling over sleeping for a fixed amount of time. The API is
+eventually consistent: it reports an intermediate state (a freshly created email is `queued`, for
+example) until processing finishes, so sleeping and then asserting once is a race that slower
+machines lose. Two helpers exist for this:
+
+- `crate::test::retry` re-runs a fallible operation until it succeeds or the attempts run out
+- `crate::test::wait_for_email_event` builds on it to poll until an email reaches a given
+  `last_event`
+
+There are still a number of `std::thread::sleep` calls left over from before those helpers
+existed. Be aware that they block a worker thread of the shared runtime rather than yielding to
+it, which also stalls whatever else is running there, so reach for `tokio::time::sleep` when a
+plain delay really is what you want.
 
 Note that because rate limiting only works for the non`blocking` feature, if more non-async tests
 are added, it might be necessary to add thread sleeps.

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -163,8 +163,10 @@ mod test {
     #[cfg(not(feature = "blocking"))]
     #[allow(clippy::unwrap_used, clippy::indexing_slicing)]
     async fn permissive_error() -> DebugResult<()> {
+        use crate::test::wait_for_email_event;
+
         let resend = &*CLIENT;
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
         let emails = vec![
             CreateEmailBaseOptions::new(
@@ -192,9 +194,8 @@ mod test {
 
         // There should be one error but apparently the errors array is empty
         // check with a get instead
-        std::thread::sleep(std::time::Duration::from_secs(4));
         let failed_id = &emails.data[1].id;
-        let status = resend.emails.get(failed_id).await?;
+        let status = wait_for_email_event(resend, failed_id, EmailEvent::Failed).await?;
         assert_eq!(status.last_event, EmailEvent::Failed);
 
         Ok(())

--- a/src/emails.rs
+++ b/src/emails.rs
@@ -684,6 +684,48 @@ mod test {
     };
     use jiff::{Span, Timestamp, Zoned};
 
+    /// Polls until the email's `scheduled_at` is `hours` out from now.
+    ///
+    /// Scheduling and rescheduling are both applied asynchronously, and the email
+    /// stays [`EmailEvent::Scheduled`] across a reschedule, so the event alone cannot
+    /// tell us the new time has landed.
+    ///
+    /// [`EmailEvent::Scheduled`]: crate::types::EmailEvent::Scheduled
+    #[cfg(not(feature = "blocking"))]
+    async fn wait_for_scheduled_at(
+        resend: &crate::Resend,
+        email_id: &str,
+        hours: i64,
+    ) -> Result<Email, crate::Error> {
+        use crate::Error;
+
+        let f = async || {
+            let email = resend.emails.get(email_id).await?;
+            let raw = email.scheduled_at.clone().ok_or_else(|| {
+                Error::Other(format!("email {email_id}: `scheduled_at` was null"))
+            })?;
+            let time = raw
+                .parse::<Timestamp>()
+                .map_err(|e| Error::Other(format!("unparseable `scheduled_at` {raw}: {e}")))?;
+            let delta = (time - Timestamp::now())
+                .round(jiff::Unit::Hour)
+                .map_err(|e| Error::Other(e.to_string()))?;
+            let ordering = delta
+                .compare(Span::new().hours(hours))
+                .map_err(|e| Error::Other(e.to_string()))?;
+
+            if ordering == std::cmp::Ordering::Equal {
+                Ok(email)
+            } else {
+                Err(Error::Other(format!(
+                    "email {email_id}: `scheduled_at` is {raw}, not {hours}h out"
+                )))
+            }
+        };
+
+        crate::test::retry(f, 30, std::time::Duration::from_secs(2)).await
+    }
+
     #[tokio_shared_rt::test(shared = true)]
     #[cfg(not(feature = "blocking"))]
     async fn all() -> DebugResult<()> {
@@ -789,6 +831,7 @@ mod test {
     #[cfg(not(feature = "blocking"))]
     async fn schedule_email() -> DebugResult<()> {
         use crate::emails::types::EmailEvent;
+        use crate::test::wait_for_email_event;
 
         let now_plus_1h = Zoned::now()
             .checked_add(Span::new().hours(1))
@@ -812,50 +855,29 @@ mod test {
         let email = CreateEmailBaseOptions::new(from, to, subject)
             .with_text("Hello World!")
             .with_scheduled_at(&now_plus_1h);
-        let email = resend.emails.send(email).await?;
-        std::thread::sleep(std::time::Duration::from_secs(4));
+        let email_id = resend.emails.send(email).await?.id;
 
-        // Get
-        let email = resend.emails.get(&email.id).await?;
+        // Get. A newly created email is `Queued` until Resend processes it, so wait
+        // for the transition rather than assuming a fixed delay is long enough.
+        let email = wait_for_email_event(resend, &email_id, EmailEvent::Scheduled).await?;
         assert_eq!(email.last_event, EmailEvent::Scheduled);
+        let email = wait_for_scheduled_at(resend, &email_id, 1).await?;
         assert!(email.scheduled_at.is_some());
-        let time = email
-            .scheduled_at
-            .unwrap()
-            .parse::<Timestamp>()
-            .expect("Valid timestamp");
-        let time_delta = (time - Timestamp::now()).round(jiff::Unit::Hour).unwrap();
-        assert_eq!(
-            time_delta.compare(Span::new().hours(1)).unwrap(),
-            std::cmp::Ordering::Equal
-        );
 
         // Update
         let changes = UpdateEmailOptions::new().with_scheduled_at(&now_plus_2h);
-        let email = resend.emails.update(&email.id, changes).await?;
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        let _updated = resend.emails.update(&email_id, changes).await?;
 
         // Get
-        let email = resend.emails.get(&email.id).await?;
+        let email = wait_for_scheduled_at(resend, &email_id, 2).await?;
         assert_eq!(email.last_event, EmailEvent::Scheduled);
         assert!(email.scheduled_at.is_some());
-        let time = email
-            .scheduled_at
-            .unwrap()
-            .parse::<Timestamp>()
-            .expect("Valid timestamp");
-        let time_delta = (time - Timestamp::now()).round(jiff::Unit::Hour).unwrap();
-        assert_eq!(
-            time_delta.compare(Span::new().hours(2)).unwrap(),
-            std::cmp::Ordering::Equal
-        );
 
         // Cancel
-        let _cancelled = resend.emails.cancel(&email.id).await?;
-        std::thread::sleep(std::time::Duration::from_secs(1));
+        let _cancelled = resend.emails.cancel(&email_id).await?;
 
         // Get again, make sure it was cancelled
-        let email = resend.emails.get(&email.id).await?;
+        let email = wait_for_email_event(resend, &email_id, EmailEvent::Canceled).await?;
         assert_eq!(email.last_event, EmailEvent::Canceled);
 
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -332,4 +332,34 @@ mod test {
             }
         }
     }
+
+    /// Polls `emails.get` until `last_event` reaches `expected`.
+    ///
+    /// Email state is eventually consistent: a freshly created email reports
+    /// [`EmailEvent::Queued`] until Resend actually attempts delivery, so sleeping a
+    /// fixed amount and asserting once is a race. Busier or slower CI runners lose
+    /// that race regularly, which is what this replaces.
+    ///
+    /// [`EmailEvent::Queued`]: crate::types::EmailEvent::Queued
+    #[allow(clippy::redundant_pub_crate)]
+    #[cfg(not(feature = "blocking"))]
+    pub(crate) async fn wait_for_email_event(
+        resend: &Resend,
+        email_id: &str,
+        expected: crate::types::EmailEvent,
+    ) -> Result<crate::types::Email, Error> {
+        let f = async || {
+            let email = resend.emails.get(email_id).await?;
+            if email.last_event == expected {
+                Ok(email)
+            } else {
+                Err(Error::Other(format!(
+                    "email {email_id}: expected `{expected:?}`, still `{:?}`",
+                    email.last_event
+                )))
+            }
+        };
+
+        retry(f, 30, std::time::Duration::from_secs(2)).await
+    }
 }


### PR DESCRIPTION
Fixes two tests that fail intermittently against the live API. Test-only change plus a `CONTRIBUTING.md` update. No library code touched, so no CHANGELOG entry.

## What was failing

```
---- batch::test::permissive_error stdout ----
panicked at src/batch.rs:198: assertion `left == right` failed
  left: Queued
 right: Failed

---- emails::test::schedule_email stdout ----
panicked at src/emails.rs:820: assertion `left == right` failed
  left: Queued
 right: Scheduled
```

## Root cause

Both are the same race, not a platform bug. Each test sleeps a fixed number of seconds and then asserts once on server-side state that is eventually consistent. `Queued` is the initial state; the assertion runs before Resend has transitioned out of it. Busier or slower runners lose the race more often, but raising the sleep only lengthens the odds. It doesn't remove the race.

`schedule_email` is worse than the failure suggests: it has **three** such assertions (lines 820, 840, 859). It died on the first, so the other two have effectively never been exercised. Fixing only the reported line would just move the failure to line 840.

## The fix

Poll until the expected state, or give up after a deadline. This builds on the existing `retry` helper in `src/lib.rs` (already used in `domains.rs`) rather than introducing new machinery:

- **`wait_for_email_event`** (`src/lib.rs`);  polls `emails.get` until `last_event` matches. Used for `Scheduled`, `Canceled` and `Failed`. 30 attempts, 2s apart.
- **`wait_for_scheduled_at`** (`src/emails.rs`); the post-reschedule assertion needs a *different* predicate: the email stays `Scheduled` across a `PATCH`, so the event alone can't tell you the new time has landed. This polls on the `scheduled_at` value instead.

Incidentally removes 5 of the 74 `std::thread::sleep` calls (from 74 to 69). The rest are untouched here.

## `CONTRIBUTING.md`

The guide currently documents the approach this PR moves away from:

> There are some thread sleep statements here and there to make sure that calls that create a resource have been properly processed

Updated to describe polling as the preferred approach and point at the two helpers, while noting the remaining sleeps still exist. It also now notes that `std::thread::sleep` blocks a worker of the shared runtime rather than yielding to it, which stalls whatever else is scheduled there. That is relevant given the tests run on `tokio_shared_rt::test(shared = true)`.

## Verification

**This PR's CI cannot validate the fix.** `ci.yml` triggers only on `push: branches: [main]`, not on `pull_request`, so the tests it repairs won't run until after merge. That's plausibly how the flake got in.

I don't have API credentials, so I verified against a local mock that reproduces the eventual consistency. Each phase returns the stale value for its first two GETs:

```
GET n=1 last_event=queued          <- polled through
GET n=2 last_event=queued
GET n=3 last_event=scheduled       ok
PATCH -> n=1,2 scheduled_at=+1h (stale) -> n=3 +2h   ok
cancel -> n=1,2 scheduled -> n=3 canceled            ok
test emails::test::schedule_email ... ok
```

The control matters more than the green run: against the *same* mock, the pre-fix code fails with `left: Queued, right: Scheduled`, character-for-character the CI error above. So the mock reproduces the real defect and the polling is what resolves it. Happy to attach the mock script, or fold it in as a starting point if you'd ever want mocked tests in-tree.

Also confirmed: `cargo fmt --check` clean, `cargo clippy --all-features -- -Dwarnings` exit 0, and tests compile under both async and `blocking`.

## Trade-off worth knowing

`retry` retries *any* error, including transport errors. With a bad key or no network these two tests now take up to 60s to fail instead of failing immediately. Harmless in CI, mildly annoying locally. Making it fail fast means distinguishing "wrong state" from `Error::Http`, which `retry` can't express today. I left that alone rather than widen the diff, but happy to add it if you'd prefer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes flaky email-state tests by polling for eventual consistency instead of using fixed sleeps. Test-only change plus a `CONTRIBUTING.md` update; no runtime behavior changes.

- **Bug Fixes**
  - Replaced fixed sleeps with polling for email state in tests to handle eventual consistency.
  - Added `wait_for_email_event` (polls `emails.get` until the expected `last_event`) and `wait_for_scheduled_at` (polls `scheduled_at` after schedule/reschedule).
  - Updated `emails::test::schedule_email` and `batch::test::permissive_error` to use the helpers; removed several blocking sleeps and used `tokio::time::sleep` where a delay is still needed.

- **Docs**
  - Updated `CONTRIBUTING.md` to recommend polling over `std::thread::sleep`, point to the new helpers, and note that blocking sleeps stall the shared Tokio runtime.

<sup>Written for commit 276607f1ebda7b02df640a05fd580f9c0f24b12d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/88?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

