### PR TITLE
chore: use the API timestamp format in fixtures and docs

### DIFF
--- a/src/api_keys.rs
+++ b/src/api_keys.rs
@@ -157,7 +157,7 @@ pub mod types {
         pub id: ApiKeyId,
         /// The name of the API key.
         pub name: String,
-        /// The date and time the API key was created in ISO8601 format.
+        /// The date and time the API key was created.
         pub created_at: String,
         pub last_used_at: Option<String>,
     }

--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -594,7 +594,7 @@ pub mod types {
         pub last_name: String,
         /// Indicates if the contact is unsubscribed.
         pub unsubscribed: bool,
-        /// Timestamp indicating when the contact was created in ISO8601 format.
+        /// Timestamp indicating when the contact was created.
         pub created_at: String,
         /// Custom properties for the contact.
         #[serde(default)]
@@ -1344,7 +1344,7 @@ mod test {
   "key": "company_name",
   "type": "string",
   "fallback_value": "Acme Corp",
-  "created_at": "2023-04-08T00:11:13.110779+00:00"
+  "created_at": "2023-04-08 00:11:13.110779+00"
 }"#;
 
         let res = serde_json::from_str::<ContactProperty>(contact_property);

--- a/src/domains.rs
+++ b/src/domains.rs
@@ -470,7 +470,7 @@ pub mod types {
         /// The status of the domain.
         pub status: DomainStatus,
 
-        /// The date and time the domain was created in ISO8601 format.
+        /// The date and time the domain was created.
         pub created_at: String,
         /// The region where the domain is hosted.
         pub region: Region,
@@ -793,7 +793,7 @@ mod test {
             "id": "fd61172c-cafc-40f5-b049-b45947779a29",
             "name": "resend.com",
             "status": "partially_verified",
-            "created_at": "2023-06-21T06:10:36.144Z",
+            "created_at": "2023-06-21 06:10:36.144+00",
             "region": "us-east-1",
             "capabilities": { "sending": "enabled", "receiving": "disabled" }
         }"#;
@@ -811,7 +811,7 @@ mod test {
             "id": "fd61172c-cafc-40f5-b049-b45947779a29",
             "name": "resend.com",
             "status": "partially_failed",
-            "created_at": "2023-06-21T06:10:36.144Z",
+            "created_at": "2023-06-21 06:10:36.144+00",
             "region": "us-east-1",
             "capabilities": { "sending": "enabled", "receiving": "enabled" }
         }"#;

--- a/src/emails.rs
+++ b/src/emails.rs
@@ -551,7 +551,7 @@ pub mod types {
         /// The subject line of the email.
         pub subject: String,
 
-        /// The date and time the email was created in ISO8601 format.
+        /// The date and time the email was created.
         pub created_at: String,
         /// The HTML body of the email.
         pub html: Option<String>,
@@ -569,8 +569,7 @@ pub mod types {
         /// The status of the email.
         pub last_event: EmailEvent,
 
-        /// Schedule email to be sent later. The date should be in ISO 8601 format
-        /// (e.g: `2024-08-05T11:52:01.858Z`).
+        /// The scheduled send time of the email.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub scheduled_at: Option<String>,
     }

--- a/src/events.rs
+++ b/src/events.rs
@@ -194,7 +194,7 @@ pub mod types {
 ///     "created_at": "2024-02-22T23:41:12.126Z",
 ///     "data": {
 ///       "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-///       "created_at": "2024-02-22T23:41:11.894719+00:00",
+///       "created_at": "2024-02-22T23:41:11.894Z",
 ///       "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
 ///       "message_id": "<111-222-333@email.example.com>",
 ///       "from": "Acme <onboarding@resend.dev>",
@@ -565,7 +565,7 @@ mod test {
       "created_at": "2024-02-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-02-22T23:41:11.894719+00:00",
+        "created_at": "2024-02-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -601,7 +601,7 @@ mod test {
       "created_at": "2024-02-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-02-22T23:41:11.894719+00:00",
+        "created_at": "2024-02-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -633,7 +633,7 @@ mod test {
       "created_at": "2024-02-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-02-22T23:41:11.894719+00:00",
+        "created_at": "2024-02-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -668,7 +668,7 @@ mod test {
       "created_at": "2024-02-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-02-22T23:41:11.894719+00:00",
+        "created_at": "2024-02-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -703,7 +703,7 @@ mod test {
       "created_at": "2024-11-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-11-22T23:41:11.894719+00:00",
+        "created_at": "2024-11-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -741,7 +741,7 @@ mod test {
       "created_at": "2024-02-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-02-22T23:41:11.894719+00:00",
+        "created_at": "2024-02-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -773,7 +773,7 @@ mod test {
       "created_at": "2024-11-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-11-22T23:41:11.894719+00:00",
+        "created_at": "2024-11-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -813,7 +813,7 @@ mod test {
       "created_at": "2024-11-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-11-22T23:41:11.894719+00:00",
+        "created_at": "2024-11-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -850,7 +850,7 @@ mod test {
       "created_at": "2024-02-22T23:41:12.126Z",
       "data": {
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
-        "created_at": "2024-02-22T23:41:11.894719+00:00",
+        "created_at": "2024-02-22T23:41:11.894Z",
         "from": "Acme <onboarding@resend.dev>",
         "to": ["delivered@resend.dev"],
         "bcc": [],
@@ -898,7 +898,7 @@ mod test {
       "created_at": "2024-02-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-02-22T23:41:11.894719+00:00",
+        "created_at": "2024-02-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -932,7 +932,7 @@ mod test {
       "created_at": "2024-11-22T23:41:12.126Z",
       "data": {
         "broadcast_id": "8b146471-e88e-4322-86af-016cd36fd216",
-        "created_at": "2024-11-22T23:41:11.894719+00:00",
+        "created_at": "2024-11-22T23:41:11.894Z",
         "email_id": "56761188-7520-42d8-8898-ff6fc54ce618",
         "message_id": "<111-222-333@email.example.com>",
         "from": "Acme <onboarding@resend.dev>",
@@ -1010,7 +1010,7 @@ mod test {
         "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
         "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
         "segment_ids": ["78261eea-8f8b-4381-83c6-79fa7120f1cf"],
-        "created_at": "2024-10-10T15:11:94.110Z",
+        "created_at": "2024-10-10T15:11:54.110Z",
         "updated_at": "2024-10-11T23:47:56.678Z",
         "email": "steve.wozniak@gmail.com",
         "first_name": "Steve",
@@ -1044,7 +1044,7 @@ mod test {
         "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
         "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
         "segment_ids": ["78261eea-8f8b-4381-83c6-79fa7120f1cf"],
-        "created_at": "2024-11-10T15:11:94.110Z",
+        "created_at": "2024-11-10T15:11:54.110Z",
         "updated_at": "2024-11-17T19:32:22.980Z",
         "email": "steve.wozniak@gmail.com",
         "first_name": "Steve",

--- a/src/receiving.rs
+++ b/src/receiving.rs
@@ -451,7 +451,7 @@ mod test {
       "message_id": "<111-222-333@email.provider.example.com>",
       "raw": {
         "download_url": "https://example.com/emails/raw/abc123?signature=xyz789",
-        "expires_at": "2023-04-08T00:13:52.669661+00:00"
+        "expires_at": "2023-04-08 00:13:52.669661+00"
       },
       "attachments": [
         {

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -113,7 +113,7 @@ pub mod types {
         // pub object: String,
         /// The name of the segment.
         pub name: String,
-        /// The date that the object was created in ISO8601 format.
+        /// The date that the object was created.
         pub created_at: String,
     }
 

--- a/src/suppressions.rs
+++ b/src/suppressions.rs
@@ -318,7 +318,7 @@ mod test {
         "email": "steve.wozniak@example.com",
         "origin": "bounce",
         "source_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
-        "created_at": "2026-10-06T23:47:56.678Z"
+        "created_at": "2026-10-06 23:47:56.678+00"
       }"#;
         let list_suppressions = r#"{
         "object": "list",
@@ -330,7 +330,7 @@ mod test {
             "email": "steve.wozniak@example.com",
             "origin": "manual",
             "source_id": null,
-            "created_at": "2026-10-06T23:47:56.678Z"
+            "created_at": "2026-10-06 23:47:56.678+00"
           },
           {
             "object": "suppression",
@@ -338,7 +338,7 @@ mod test {
             "email": "susan.kare@example.com",
             "origin": "bounce",
             "source_id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
-            "created_at": "2026-10-07T08:12:03.412Z"
+            "created_at": "2026-10-07 08:12:03.412+00"
           }
         ]
       }"#;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -544,10 +544,10 @@ mod test {
   "id": "34a080c9-b17d-4187-ad80-5af20266e535",
   "alias": "reset-password",
   "name": "reset-password",
-  "created_at": "2023-10-06T23:47:56.678Z",
-  "updated_at": "2023-10-06T23:47:56.678Z",
+  "created_at": "2023-10-06 23:47:56.678+00",
+  "updated_at": "2023-10-06 23:47:56.678+00",
   "status": "published",
-  "published_at": "2023-10-06T23:47:56.678Z",
+  "published_at": "2023-10-06 23:47:56.678+00",
   "from": "John Doe <john.doe@example.com>",
   "subject": "Hello, world!",
   "reply_to": null,
@@ -559,8 +559,8 @@ mod test {
       "key": "user_name",
       "type": "string",
       "fallback_value": "John Doe",
-      "created_at": "2023-10-06T23:47:56.678Z",
-      "updated_at": "2023-10-06T23:47:56.678Z"
+      "created_at": "2023-10-06 23:47:56.678+00",
+      "updated_at": "2023-10-06 23:47:56.678+00"
     }
   ]
 }"#;
@@ -576,10 +576,10 @@ mod test {
   "id": "34a080c9-b17d-4187-ad80-5af20266e535",
   "alias": "reset-password",
   "name": "reset-password",
-  "created_at": "2023-10-06T23:47:56.678Z",
-  "updated_at": "2023-10-06T23:47:56.678Z",
+  "created_at": "2023-10-06 23:47:56.678+00",
+  "updated_at": "2023-10-06 23:47:56.678+00",
   "status": "published",
-  "published_at": "2023-10-06T23:47:56.678Z",
+  "published_at": "2023-10-06 23:47:56.678+00",
   "from": "John Doe <john.doe@example.com>",
   "subject": "Hello, world!",
   "reply_to": null,

--- a/src/topics.rs
+++ b/src/topics.rs
@@ -297,7 +297,7 @@ mod test {
   "description": "Weekly newsletter for our subscribers",
   "default_subscription": "opt_in",
   "visibility": "public",
-  "created_at": "2023-04-08T00:11:13.110779+00:00"
+  "created_at": "2023-04-08 00:11:13.110779+00"
 }"#;
 
         let res = serde_json::from_str::<Topic>(topic);

--- a/src/webhooks.rs
+++ b/src/webhooks.rs
@@ -268,7 +268,7 @@ mod test {
         let webhook = r#"{
   "object": "webhook",
   "id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
-  "created_at": "2023-08-22T15:28:00.000Z",
+  "created_at": "2023-08-22 15:28:00+00",
   "status": "enabled",
   "endpoint": "https://webhook.example.com/handler",
   "events": ["email.sent", "email.received"],


### PR DESCRIPTION
## Context for reviewers

The Resend API returns timestamps in Postgres text format: `YYYY-MM-DD HH:MM:SS[.ffffff]+00` (for example `2023-10-06 23:47:56.678+00`). It is not ISO 8601. Fractional seconds vary from zero to six digits, so no fixed width can be assumed.

Our docs, OpenAPI spec, and SDK test fixtures claimed ISO 8601 for a long time. We fixed the docs and the spec, and we are now updating every SDK so the fixtures show what the API really sends. The SDKs treat these values as opaque strings, so behavior does not change.

ISO 8601 remains correct in three places: `scheduled_at` as a request parameter, webhook event payloads (millisecond precision with `Z`), and `revoked_at` in the DELETE `/oauth/grants/{id}` response.

## What

- Convert 17 response-fixture timestamps in the deserialize tests (`contacts`, `domains`, `receiving`, `suppressions`, `templates`, `topics`, `webhooks`).
- Remove the `ISO8601` claims from six response-field doc comments. `Email.scheduled_at` on the retrieve response also had the request-side doc copied onto it; it now describes the field without a format claim.
- Fix 12 webhook fixtures in `events.rs` from microsecond `+00:00` to millisecond `Z`. Real webhooks emit millisecond precision.
- Fix two fixtures that contained the invalid time `15:11:94`.

## What stays ISO 8601 on purpose

- `scheduled_at` request-param docs (`emails.rs`, `broadcasts.rs`).
- `revoked_at` in the revoke OAuth grant response (`oauth.rs`).
- Webhook envelope and non-email event payloads, already millisecond + `Z`.

## Verification

- `cargo test deserialize`: 16 passed.
- `cargo fmt --check` and `cargo clippy --all-features`: clean.
- The 21 live-API tests require `RESEND_API_KEY` and fail identically on main without it.

## Known issue, out of scope

The live `schedule_email` test parses the retrieve-response `scheduled_at` with `jiff::Timestamp`, which accepts only RFC 3339. Against the real API that value arrives in Postgres format and the parse panics. This PR does not change runtime code; we will handle that test separately.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align fixtures and response docs with the API’s Postgres-style timestamp format to match real responses and remove incorrect ISO 8601 claims. No runtime changes; all timestamp fields remain strings.

- **Refactors**
  - Convert response fixtures to Postgres text timestamps (e.g., "YYYY-MM-DD HH:MM:SS[.ffffff]+00").
  - Remove ISO 8601 mentions from response-field docs; clarify `scheduled_at` in the retrieve response.
  - Keep ISO 8601 where intended: `scheduled_at` request params, webhook payloads (ms + `Z`), and `revoked_at` in the OAuth revoke response.

- **Bug Fixes**
  - Update webhook fixtures from microsecond `+00:00` to millisecond `Z` to match real webhook output.
  - Fix two fixtures with invalid time values.

<sup>Written for commit 1131a9023cac84742cc72657fd4fd717575dfce8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

