### PR TITLE
feat: add broadcasts.cancel() method

### DIFF
--- a/src/broadcasts.rs
+++ b/src/broadcasts.rs
@@ -7,8 +7,8 @@ use crate::{Config, Result, list_opts::ListResponse};
 use crate::{
     list_opts::ListOptions,
     types::{
-        Broadcast, CreateBroadcastOptions, CreateBroadcastResponse, RemoveBroadcastResponse,
-        SendBroadcastOptions, SendBroadcastResponse,
+        Broadcast, CancelBroadcastResponse, CreateBroadcastOptions, CreateBroadcastResponse,
+        RemoveBroadcastResponse, SendBroadcastOptions, SendBroadcastResponse,
     },
 };
 
@@ -70,6 +70,17 @@ impl BroadcastsSvc {
         let request = self.0.build(Method::GET, &path);
         let response = self.0.send(request).await?;
         let content = response.json::<Broadcast>().await?;
+
+        Ok(content)
+    }
+
+    #[maybe_async::maybe_async]
+    pub async fn cancel(&self, broadcast_id: &str) -> Result<CancelBroadcastResponse> {
+        let path = format!("/broadcasts/{broadcast_id}/cancel");
+
+        let request = self.0.build(Method::POST, &path);
+        let response = self.0.send(request).await?;
+        let content = response.json::<CancelBroadcastResponse>().await?;
 
         Ok(content)
     }
@@ -349,6 +360,11 @@ pub mod types {
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct CancelBroadcastResponse {
+        pub id: BroadcastId,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct RemoveBroadcastResponse {
         /// The ID of the broadcast.
         #[allow(dead_code)]
@@ -371,7 +387,7 @@ mod test {
         },
     };
 
-    use super::types::Broadcast;
+    use super::types::{Broadcast, CancelBroadcastResponse};
 
     #[tokio_shared_rt::test(shared = true)]
     #[serial_test::serial]
@@ -514,5 +530,16 @@ mod test {
 }"#;
 
         let _parsed = serde_json::from_str::<Broadcast>(data).expect("Parsing failed");
+    }
+
+    #[test]
+    fn parse_cancel_broadcast_response_test() {
+        let data = r#"{
+    "object": "broadcast",
+    "id": "498ee8e4-7aa2-4eb5-9f04-4194848049d1"
+}"#;
+
+        let _parsed =
+            serde_json::from_str::<CancelBroadcastResponse>(data).expect("Parsing failed");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,9 +115,9 @@ pub mod types {
         SendEmailBatchResponse,
     };
     pub use super::broadcasts::types::{
-        Broadcast, BroadcastId, CreateBroadcastOptions, CreateBroadcastResponse,
-        RemoveBroadcastResponse, SendBroadcastOptions, SendBroadcastResponse,
-        UpdateBroadcastOptions, UpdateBroadcastResponse,
+        Broadcast, BroadcastId, CancelBroadcastResponse, CreateBroadcastOptions,
+        CreateBroadcastResponse, RemoveBroadcastResponse, SendBroadcastOptions,
+        SendBroadcastResponse, UpdateBroadcastOptions, UpdateBroadcastResponse,
     };
     pub use super::contacts::types::{
         AddContactSegmentResponse, Contact, ContactChanges, ContactId, ContactImport,


### PR DESCRIPTION
## Summary
- Adds `BroadcastsSvc::cancel(broadcast_id)`, calling `POST /broadcasts/:id/cancel` to cancel a queued or scheduled broadcast.
- Adds `CancelBroadcastResponse` type (id) and re-exports it from `lib.rs`, mirroring `SendBroadcastResponse`/`UpdateBroadcastResponse`.
- Adds a `parse_cancel_broadcast_response_test` deserialization test, matching the existing `parse_broadcast_test` pattern.

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122, resend/resend-php#135, resend/resend-python#250, resend/resend-ruby#216.

## Test plan
- [x] `cargo check --lib --tests` (default features) — clean
- [x] `cargo clippy --lib --tests --no-default-features --features blocking,native-tls -- -D warnings` — clean
- [x] `cargo test --lib broadcasts::` — 2 passed, 3 pre-existing ignored (live-API integration tests)
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `BroadcastsSvc::cancel()` to cancel queued or scheduled broadcasts via POST `/broadcasts/:id/cancel`. Exposes `CancelBroadcastResponse` and re-exports it in `lib.rs` to match other broadcast responses.

- New Features
  - Implement `cancel(broadcast_id)`; sends POST with no body and returns `CancelBroadcastResponse`.
  - Add `CancelBroadcastResponse { id }`; re-exported from `lib.rs`.
  - Add `parse_cancel_broadcast_response_test` for deserialization.

<sup>Written for commit e49fdc3faaf92320fada3858edb490a12f9ecc11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

