### PR TITLE
feat: expose open_tracking/click_tracking on Domain

### DIFF
--- a/src/domains.rs
+++ b/src/domains.rs
@@ -472,6 +472,13 @@ pub mod types {
         pub records: Option<Vec<DomainRecord>>,
 
         pub capabilities: DomainCapabilities,
+
+        /// Whether open tracking is enabled for this domain.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub open_tracking: Option<bool>,
+        /// Whether click tracking is enabled for this domain.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub click_tracking: Option<bool>,
     }
 
     #[must_use]
@@ -778,6 +785,27 @@ mod test {
         assert_eq!(records.len(), 2);
         assert!(matches!(records[0], DomainRecord::TrackingRecord(_)));
         assert!(matches!(records[1], DomainRecord::TrackingCaaRecord(_)));
+    }
+
+    #[test]
+    fn deserialize_domain_with_tracking_fields() {
+        use crate::domains::types::Domain;
+
+        let json = r#"{
+            "object": "domain",
+            "id": "fd61172c-cafc-40f5-b049-b45947779a29",
+            "name": "resend.com",
+            "status": "verified",
+            "created_at": "2023-06-21 06:10:36.144+00",
+            "region": "us-east-1",
+            "capabilities": { "sending": "enabled", "receiving": "disabled" },
+            "open_tracking": true,
+            "click_tracking": false
+        }"#;
+
+        let domain: Domain = serde_json::from_str(json).expect("domain deserializes");
+        assert_eq!(domain.open_tracking, Some(true));
+        assert_eq!(domain.click_tracking, Some(false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- The shared `Domain` struct (used by both `get()` and `list()`) never declared `open_tracking`/`click_tracking`, so serde silently dropped these fields on deserialization even though the API has returned them on `GET /domains/:id` for a while, and now returns them on `GET /domains` too (resend/resend-monorepo#8233).
- Added `open_tracking: Option<bool>` and `click_tracking: Option<bool>` to `Domain`, matching the existing `skip_serializing_if` pattern used elsewhere in this file (`CreateDomainOptions`, `DomainChanges`).
- Added a deserialize test covering both fields.

## Note
No Rust toolchain was available in the environment I used to make this change, so this has been reviewed carefully against existing patterns in the file but **not compiled or run locally** — `cargo test` should be run before merging.

## Test plan
- [ ] `cargo test --lib domains` passes, including the new `deserialize_domain_with_tracking_fields` test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `open_tracking` and `click_tracking` on the `Domain` type so clients can read tracking settings from both `get()` and `list()` responses. Fixes silent dropping of these fields to match `GET /domains/:id` and `GET /domains`.

- **Bug Fixes**
  - Added `open_tracking: Option<bool>` and `click_tracking: Option<bool>` with `#[serde(skip_serializing_if = "Option::is_none")]`.
  - Added a deserialization test covering both fields.

<sup>Written for commit bc47a98157582a276c3c37f6cbcdc22212a16f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/92?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

