### PR TITLE
feat(automations): duplicate endpoint

### DIFF
--- a/src/automations.rs
+++ b/src/automations.rs
@@ -7,8 +7,8 @@ use crate::{
     list_opts::{ListOptions, ListResponse},
     types::{
         Automation, AutomationMinimal, AutomationRun, CreateAutomationOptions,
-        CreateAutomationResponse, DeleteAutomationResponse, StopAutomationResponse,
-        UpdateAutomationOptions, UpdateAutomationResponse,
+        CreateAutomationResponse, DeleteAutomationResponse, DuplicateAutomationResponse,
+        StopAutomationResponse, UpdateAutomationOptions, UpdateAutomationResponse,
     },
 };
 
@@ -89,6 +89,20 @@ impl AutomationsSvc {
         let request = self.0.build(Method::POST, &path);
         let response = self.0.send(request).await?;
         let content = response.json::<StopAutomationResponse>().await?;
+
+        Ok(content)
+    }
+
+    /// Duplicate an existing automation.
+    ///
+    /// <https://resend.com/docs/api-reference/automations/duplicate-automation>
+    #[maybe_async::maybe_async]
+    pub async fn duplicate(&self, automation_id: &str) -> Result<DuplicateAutomationResponse> {
+        let path = format!("/automations/{automation_id}/duplicate");
+
+        let request = self.0.build(Method::POST, &path);
+        let response = self.0.send(request).await?;
+        let content = response.json::<DuplicateAutomationResponse>().await?;
 
         Ok(content)
     }
@@ -429,6 +443,12 @@ pub mod types {
         pub status: AutomationStatus,
     }
 
+    #[must_use]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct DuplicateAutomationResponse {
+        pub id: AutomationId,
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct DeleteAutomationResponse {
         pub id: AutomationId,
@@ -593,6 +613,12 @@ mod test {
             .list_runs(&automation.id, None, ListOptions::default())
             .await?;
         assert!(runs.data.is_empty());
+
+        // Duplicate
+        let duplicated = resend.automations.duplicate(&automation.id).await?;
+        std::thread::sleep(std::time::Duration::from_secs(2));
+        let deleted = resend.automations.delete(&duplicated.id).await?;
+        assert!(deleted.deleted);
 
         // Stop
         let automation = resend.automations.stop(&automation.id).await?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,9 @@ pub mod types {
         AddToSegmentStepConfig, Automation, AutomationId, AutomationMinimal, AutomationRun,
         AutomationRunId, AutomationStatus, AutomationTemplate, Connection, ConnectionType,
         CreateAutomationOptions, CreateAutomationResponse, DelayStepConfig,
-        DeleteAutomationResponse, SendEmailStepConfig, Step, StopAutomationResponse,
-        TriggerStepConfig, UpdateAutomationOptions, UpdateAutomationResponse,
-        WaitForEventStepConfig,
+        DeleteAutomationResponse, DuplicateAutomationResponse, SendEmailStepConfig, Step,
+        StopAutomationResponse, TriggerStepConfig, UpdateAutomationOptions,
+        UpdateAutomationResponse, WaitForEventStepConfig,
     };
     pub use super::batch::types::{
         BatchValidation, PermissiveBatchErrors, SendEmailBatchPermissiveResponse,


### PR DESCRIPTION
Adds `resend.automations.duplicate(automation_id)` for `POST /automations/{id}/duplicate`, returning `DuplicateAutomationResponse`.

Resolves DEV-1710. Mirrors the existing `stop` pattern and resend-node https://github.com/resend/resend-node/pull/1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `resend.automations.duplicate(automation_id)` to duplicate an automation via `POST /automations/{id}/duplicate`. Previously the Rust SDK lacked duplication; now it returns `DuplicateAutomationResponse` with the new automation `id`. Supports DEV-1710 parity with other SDKs.

- Implements `AutomationsSvc.duplicate` following the existing `stop` pattern and `maybe_async`.
- Introduces `types::DuplicateAutomationResponse` and re-exports it from `src/lib.rs`.
- Adds a test for duplicate→delete; no breaking changes or migrations required.

<sup>Written for commit 7f50b06ef0e3a3301f0b50c0c443aba4dd57ae57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

