### PR TITLE
feat: add broadcasts.clicked_links() method

### DIFF
--- a/src/broadcasts.rs
+++ b/src/broadcasts.rs
@@ -580,17 +580,23 @@ mod test {
     #[test]
     fn parse_broadcast_clicked_links_test() {
         let data = r#"{
-    "object": "list",
-    "has_more": false,
-    "data": [
-        {
-            "id": "b2Zmc2V0OjA",
-            "url": "https://resend.com/pricing",
-            "clicks": 42,
-            "unique_clicks": 30
-        }
-    ]
-}"#;
+          "object": "list",
+          "has_more": true,
+          "data": [
+            {
+              "id": "b2Zmc2V0OjA",
+              "url": "https://resend.com/pricing",
+              "clicks": 42,
+              "unique_clicks": 30
+            },
+            {
+              "id": "b2Zmc2V0OjE",
+              "url": "https://resend.com/docs",
+              "clicks": 17,
+              "unique_clicks": 15
+            }
+          ]
+        }"#;
 
         let _parsed =
             serde_json::from_str::<crate::list_opts::ListResponse<BroadcastClickedLink>>(data)

--- a/src/broadcasts.rs
+++ b/src/broadcasts.rs
@@ -7,8 +7,9 @@ use crate::{Config, Result, list_opts::ListResponse};
 use crate::{
     list_opts::ListOptions,
     types::{
-        Broadcast, CancelBroadcastResponse, CreateBroadcastOptions, CreateBroadcastResponse,
-        RemoveBroadcastResponse, SendBroadcastOptions, SendBroadcastResponse,
+        Broadcast, BroadcastClickedLink, CancelBroadcastResponse, CreateBroadcastOptions,
+        CreateBroadcastResponse, RemoveBroadcastResponse, SendBroadcastOptions,
+        SendBroadcastResponse,
     },
 };
 
@@ -97,6 +98,26 @@ impl BroadcastsSvc {
         let content = response.json::<RemoveBroadcastResponse>().await?;
 
         Ok(content.deleted)
+    }
+
+    /// Retrieve the links clicked in a broadcast, ranked by total clicks.
+    ///
+    /// <https://resend.com/docs/api-reference/broadcasts/list-broadcast-clicked-links>
+    #[maybe_async::maybe_async]
+    pub async fn clicked_links<T>(
+        &self,
+        broadcast_id: &str,
+        list_opts: ListOptions<T>,
+    ) -> Result<ListResponse<BroadcastClickedLink>> {
+        let path = format!("/broadcasts/{broadcast_id}/clicked-links");
+
+        let request = self.0.build(Method::GET, &path).query(&list_opts);
+        let response = self.0.send(request).await?;
+        let content = response
+            .json::<ListResponse<BroadcastClickedLink>>()
+            .await?;
+
+        Ok(content)
     }
 
     /// Update a broadcast to send to your audience.
@@ -372,6 +393,19 @@ pub mod types {
         /// The deleted attribute indicates that the corresponding broadcast has been deleted.
         pub deleted: bool,
     }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct BroadcastClickedLink {
+        /// An opaque cursor for this row, used only for pagination. It does not identify any
+        /// entity in Resend.
+        pub id: String,
+        /// The URL that was clicked.
+        pub url: String,
+        /// Total number of clicks on this URL.
+        pub clicks: u64,
+        /// Number of unique clicks on this URL.
+        pub unique_clicks: u64,
+    }
 }
 
 #[cfg(test)]
@@ -387,7 +421,7 @@ mod test {
         },
     };
 
-    use super::types::{Broadcast, CancelBroadcastResponse};
+    use super::types::{Broadcast, BroadcastClickedLink, CancelBroadcastResponse};
 
     #[tokio_shared_rt::test(shared = true)]
     #[serial_test::serial]
@@ -541,5 +575,25 @@ mod test {
 
         let _parsed =
             serde_json::from_str::<CancelBroadcastResponse>(data).expect("Parsing failed");
+    }
+
+    #[test]
+    fn parse_broadcast_clicked_links_test() {
+        let data = r#"{
+    "object": "list",
+    "has_more": false,
+    "data": [
+        {
+            "id": "b2Zmc2V0OjA",
+            "url": "https://resend.com/pricing",
+            "clicks": 42,
+            "unique_clicks": 30
+        }
+    ]
+}"#;
+
+        let _parsed =
+            serde_json::from_str::<crate::list_opts::ListResponse<BroadcastClickedLink>>(data)
+                .expect("Parsing failed");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,9 +116,10 @@ pub mod types {
         SendEmailBatchResponse,
     };
     pub use super::broadcasts::types::{
-        Broadcast, BroadcastId, CancelBroadcastResponse, CreateBroadcastOptions,
-        CreateBroadcastResponse, RemoveBroadcastResponse, SendBroadcastOptions,
-        SendBroadcastResponse, UpdateBroadcastOptions, UpdateBroadcastResponse,
+        Broadcast, BroadcastClickedLink, BroadcastId, CancelBroadcastResponse,
+        CreateBroadcastOptions, CreateBroadcastResponse, RemoveBroadcastResponse,
+        SendBroadcastOptions, SendBroadcastResponse, UpdateBroadcastOptions,
+        UpdateBroadcastResponse,
     };
     pub use super::contacts::types::{
         AddContactSegmentResponse, Contact, ContactChanges, ContactId, ContactImport,


### PR DESCRIPTION
Adds `GET /broadcasts/{id}/clicked-links` — paginated list of a broadcast's clicked links (`url`, `clicks`, `unique_clicks`).

Spec: resend/resend-openapi#95
Reference implementation: resend/resend-node#1077

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `BroadcastsSvc::clicked_links` to retrieve a broadcast’s clicked links via `GET /broadcasts/{id}/clicked-links`, enabling paginated totals and unique counts per URL. Previously unavailable; now clients can analyze per-URL engagement for a broadcast.

- Returns `ListResponse<BroadcastClickedLink>` and accepts `ListOptions`.
- Introduces `BroadcastClickedLink { id, url, clicks, unique_clicks }`; `id` is an opaque pagination cursor. Re-exported under `crate::types`.
- Adds a parsing test with updated sample payload; no changes to existing methods.

<sup>Written for commit 75bd0c20eba56bd1d9ee2c994d96706727052737. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

