### PR TITLE
feat(segments): add update endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,7 +163,9 @@ pub mod types {
         GetInboundEmailRaw, InboundAttachment, InboundAttachmentId, InboundEmail,
         InboundEmailHtmlFormat, InboundEmailId,
     };
-    pub use super::segments::types::{CreateSegmentResponse, Segment, SegmentId};
+    pub use super::segments::types::{
+        CreateSegmentResponse, Segment, SegmentId, UpdateSegmentResponse,
+    };
     pub use super::suppressions::types::{
         AddSuppressionOptions, AddSuppressionResponse, BatchAddSuppressionOptions,
         BatchAddSuppressionResponse, BatchRemoveSuppressionOptions,

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -6,7 +6,7 @@ use reqwest::Method;
 use crate::{Config, Result, list_opts::ListOptions};
 use crate::{list_opts::ListResponse, types::Segment};
 
-use self::types::CreateSegmentResponse;
+use self::types::{CreateSegmentResponse, UpdateSegmentResponse};
 
 /// `Resend` APIs for `/segments` endpoints.
 #[derive(Clone)]
@@ -41,6 +41,24 @@ impl SegmentsSvc {
         let request = self.0.build(Method::GET, &path);
         let response = self.0.send(request).await?;
         let content = response.json::<Segment>().await?;
+
+        Ok(content)
+    }
+
+    /// Update the name of an existing segment.
+    ///
+    /// <https://resend.com/docs/api-reference/segments/update-segment>
+    #[maybe_async::maybe_async]
+    pub async fn update(&self, id: &str, name: &str) -> Result<UpdateSegmentResponse> {
+        let path = format!("/segments/{id}");
+
+        let segment = types::UpdateSegmentRequest {
+            name: name.to_owned(),
+        };
+
+        let request = self.0.build(Method::PATCH, &path);
+        let response = self.0.send(request.json(&segment)).await?;
+        let content = response.json::<UpdateSegmentResponse>().await?;
 
         Ok(content)
     }
@@ -101,6 +119,21 @@ pub mod types {
         pub name: String,
     }
 
+    #[must_use]
+    #[derive(Debug, Clone, Serialize)]
+    pub struct UpdateSegmentRequest {
+        /// The new name for the segment.
+        pub name: String,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct UpdateSegmentResponse {
+        /// The ID of the segment.
+        pub id: SegmentId,
+        /// The new name of the segment.
+        pub name: String,
+    }
+
     /// Name and ID of an existing contact list.
     #[must_use]
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -150,6 +183,11 @@ mod test {
         let data = resend.segments.get(&id).await?;
         assert_eq!(data.name.as_str(), segment);
 
+        // Update.
+        let renamed = "test_segments_renamed";
+        let updated = resend.segments.update(&id, renamed).await?;
+        assert_eq!(updated.name.as_str(), renamed);
+
         // List.
         let segments = resend.segments.list(ListOptions::default()).await?;
         let segments_before = segments.len();
@@ -160,5 +198,19 @@ mod test {
         assert!(deleted);
 
         Ok(())
+    }
+
+    #[test]
+    fn deserialize_update_response() {
+        use crate::types::UpdateSegmentResponse;
+
+        let json = r#"{
+            "object": "segment",
+            "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            "name": "Registered Users"
+        }"#;
+
+        let res = serde_json::from_str::<UpdateSegmentResponse>(json);
+        assert!(res.is_ok());
     }
 }

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -210,7 +210,9 @@ mod test {
             "name": "Registered Users"
         }"#;
 
-        let res = serde_json::from_str::<UpdateSegmentResponse>(json);
-        assert!(res.is_ok());
+        let res = serde_json::from_str::<UpdateSegmentResponse>(json)
+            .expect("valid UpdateSegmentResponse JSON");
+        assert_eq!(res.id.as_ref(), "b6d24b8e-af0b-4c3c-be0c-359bbd97381e");
+        assert_eq!(res.name, "Registered Users");
     }
 }

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -172,26 +172,24 @@ mod test {
         let resend = &*CLIENT;
         let segment = "test_segments";
 
-        // Create.
         let created = resend.segments.create(segment).await?;
         let id = created.id;
         std::thread::sleep(std::time::Duration::from_secs(2));
 
-        // Get.
         let data = resend.segments.get(&id).await?;
         assert_eq!(data.name.as_str(), segment);
 
-        // Update.
         let renamed = "test_segments_renamed";
         let updated = resend.segments.update(&id, renamed).await?;
         assert_eq!(updated.id, id);
 
-        // List.
+        let refetched = resend.segments.get(&id).await?;
+        assert_eq!(refetched.name.as_str(), renamed);
+
         let segments = resend.segments.list(ListOptions::default()).await?;
         let segments_before = segments.len();
         assert!(segments_before > 1);
 
-        // Delete.
         let deleted = resend.segments.delete(&id).await?;
         assert!(deleted);
 

--- a/src/segments.rs
+++ b/src/segments.rs
@@ -130,8 +130,6 @@ pub mod types {
     pub struct UpdateSegmentResponse {
         /// The ID of the segment.
         pub id: SegmentId,
-        /// The new name of the segment.
-        pub name: String,
     }
 
     /// Name and ID of an existing contact list.
@@ -186,7 +184,7 @@ mod test {
         // Update.
         let renamed = "test_segments_renamed";
         let updated = resend.segments.update(&id, renamed).await?;
-        assert_eq!(updated.name.as_str(), renamed);
+        assert_eq!(updated.id, id);
 
         // List.
         let segments = resend.segments.list(ListOptions::default()).await?;
@@ -206,13 +204,11 @@ mod test {
 
         let json = r#"{
             "object": "segment",
-            "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-            "name": "Registered Users"
+            "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
         }"#;
 
         let res = serde_json::from_str::<UpdateSegmentResponse>(json)
             .expect("valid UpdateSegmentResponse JSON");
         assert_eq!(res.id.as_ref(), "b6d24b8e-af0b-4c3c-be0c-359bbd97381e");
-        assert_eq!(res.name, "Registered Users");
     }
 }


### PR DESCRIPTION
Adds `SegmentsSvc::update` for `PATCH /segments/:id`, renaming an existing segment.

```rust
let updated = resend.segments.update(&segment.id, "Registered Users").await?;
println!("{}", updated.name);
```

**Params**
- `name` (string, required) — the new name for the segment.

**Response**
```json
{ "object": "segment", "id": "..."}
```