### PR TITLE
fix: allow clippy::result_large_err in axum-verify-event-middleware example

### DIFF
--- a/examples/axum-verify-event-middleware.rs
+++ b/examples/axum-verify-event-middleware.rs
@@ -44,6 +44,9 @@ async fn handler(data: String) -> StatusCode {
 }
 
 // Mostly taken from https://github.com/tokio-rs/axum/blob/main/examples/consume-body-in-extractor-or-middleware/src/main.rs
+// Response must stay unboxed here: axum's IntoResponse is implemented for
+// Result<T, Response> directly, not for a boxed error variant.
+#[allow(clippy::result_large_err)]
 async fn verify_middleware(
     headers: HeaderMap,
     request: Request,

--- a/examples/axum-verify-event-middleware.rs
+++ b/examples/axum-verify-event-middleware.rs
@@ -44,28 +44,44 @@ async fn handler(data: String) -> StatusCode {
 }
 
 // Mostly taken from https://github.com/tokio-rs/axum/blob/main/examples/consume-body-in-extractor-or-middleware/src/main.rs
-// Response must stay unboxed here: axum's IntoResponse is implemented for
-// Result<T, Response> directly, not for a boxed error variant.
-#[allow(clippy::result_large_err)]
 async fn verify_middleware(
     headers: HeaderMap,
     request: Request,
     next: Next,
-) -> Result<impl IntoResponse, Response> {
+) -> Result<impl IntoResponse, AppError> {
     let (parts, body) = request.into_parts();
 
     let bytes = body
         .collect()
         .await
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response())?
+        .map_err(|_e| AppError::BodyCollect)?
         .to_bytes();
 
     let secret = "<YOUR RESEND SIGNING SECRET HERE>".to_string();
     let wh = Webhook::new(&secret).expect("Invalid secret");
     wh.verify(&bytes, &headers)
-        .map_err(|err| (StatusCode::INTERNAL_SERVER_ERROR, err.to_string()).into_response())?;
+        .map_err(|_e| AppError::WebhookVerify)?;
 
     let request = Request::from_parts(parts, Body::from(bytes));
 
     Ok(next.run(request).await)
+}
+
+#[derive(Debug)]
+enum AppError {
+    BodyCollect,
+    WebhookVerify,
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, message) = match self {
+            Self::BodyCollect => (StatusCode::INTERNAL_SERVER_ERROR, "Failed to collect body"),
+            Self::WebhookVerify => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Webhook verification failed",
+            ),
+        };
+        (status, message).into_response()
+    }
 }


### PR DESCRIPTION
## What

CI's lint job was failing on \`main\` due to dependency drift — \`axum::http::Response<Body>\` grew past clippy's \`result_large_err\` threshold (128 bytes), unrelated to any recent change to this file.

## Why not box it

Clippy suggests \`Box<Response>\`, but axum's \`IntoResponse\` is implemented for \`Result<T, Response>\` directly, not for a boxed error variant — boxing would break the middleware's return type. \`#[allow(clippy::result_large_err)]\` is the correct fix here.

Verified: \`cargo clippy --all-features --all-targets --examples -- -D warnings\`, \`cargo build --examples\`, \`cargo fmt --check\` all pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI lint failure on `main` by replacing the large `axum::http::Response` error type with a custom `AppError` enum in the axum verify-event-middleware example.

<sup>Written for commit 278df1074717ec972a9dfdef8692b0157a101928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

