### PR TITLE
feat(contacts): support custom properties in contact updates

### DIFF
--- a/src/contacts.rs
+++ b/src/contacts.rs
@@ -600,6 +600,9 @@ pub mod types {
         /// Indicates the subscription status of the contact.
         #[serde(skip_serializing_if = "Option::is_none")]
         unsubscribed: Option<bool>,
+        /// Custom properties for the contact.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        properties: Option<HashMap<String, String>>,
     }
 
     impl ContactChanges {
@@ -627,6 +630,22 @@ pub mod types {
         #[inline]
         pub const fn with_unsubscribed(mut self, unsubscribed: bool) -> Self {
             self.unsubscribed = Some(unsubscribed);
+            self
+        }
+
+        /// Updates a custom property of the contact.
+        #[inline]
+        pub fn with_property(mut self, key: &str, value: &str) -> Self {
+            let properties = self.properties.get_or_insert_with(HashMap::new);
+            let _old = properties.insert(key.to_owned(), value.to_owned());
+            self
+        }
+
+        /// Updates custom properties of the contact.
+        #[inline]
+        pub fn with_properties(mut self, properties: HashMap<String, String>) -> Self {
+            let self_properties = self.properties.get_or_insert_with(HashMap::new);
+            self_properties.extend(properties);
             self
         }
     }
@@ -1148,6 +1167,14 @@ mod test {
         let contact = resend.contacts.create(contact).await?;
 
         let contact = resend.contacts.get(&contact).await?;
+
+        let changes = ContactChanges::new().with_property("key", "updated");
+        let _contact = resend.contacts.update(&contact.id, changes).await?;
+        std::thread::sleep(std::time::Duration::from_secs(4));
+
+        let contact = resend.contacts.get(&contact.id).await?;
+        let properties = contact.properties.as_ref().expect("contact has properties");
+        assert_eq!(properties["key"].value, "updated");
 
         let deleted = resend.contacts.delete(&contact.id).await?;
         assert!(deleted);


### PR DESCRIPTION
The API accepts a `properties` object on `PATCH /contacts/:id`. The SDK's update payload, `ContactChanges`, did not expose it. The SDK could set custom properties on create and map them on import, but it could not change them on an existing contact.

This adds the `properties` field to `ContactChanges`, plus `with_property` and `with_properties` builders. The field and builders mirror `CreateContactOptions`, so both payloads serialize the same way, and serde skips the field when unset.

The `contact_properties` live test now covers the update path. It updates a property and asserts the new value after a get.

Start at `src/contacts.rs:605` for the field, `src/contacts.rs:638` for the builders, and `src/contacts.rs:1171` for the test.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom property support to contact updates so existing contacts can have their property values changed, which was previously only possible on create and import.

- `ContactChanges` now accepts a `properties` object on `PATCH /contacts/:id`.
- Adds `with_property` and `with_properties` builders that merge into the existing property map on repeated calls.
- The live `contact_properties` test now updates and verifies a property, but pauses 4 seconds to wait for propagation.

<sup>Written for commit a5248b43077b215f24f720c2f7d7508f63262054. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

