### PR TITLE
feat: allow CNAME variant for SPF record type

### DIFF
--- a/src/domains.rs
+++ b/src/domains.rs
@@ -427,6 +427,8 @@ pub mod types {
         MX,
         #[allow(clippy::upper_case_acronyms)]
         TXT,
+        #[allow(clippy::upper_case_acronyms)]
+        CNAME,
     }
 
     #[derive(Debug, Copy, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
`SpfRecordType` only had `MX` and `TXT`, so deserializing a `Domain` whose SPF record has `"type": "CNAME"` fails at runtime. Domains on Resend's internal MTA use a managed CNAME for the return path instead of the classic MX+TXT pair, so the API can return `type: "CNAME"` on an SPF record. This adds the `CNAME` variant.

Without this, `serde` errors on those domains (unknown variant), so it is a real deserialization fix, not just a typing nicety.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `CNAME` variant to `SpfRecordType` so domains with an SPF record of type `"CNAME"` deserialize successfully. Previously only `MX` and `TXT` were accepted, causing `serde` errors on those domains.

<sup>Written for commit 1a670fbaab5d5a68bd47837d3a7f4eaae2835756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-rust/pull/106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

