### PR TITLE
feat(webhooks): add event replay endpoint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,10 +183,11 @@ pub mod types {
         TopicId, TopicVisibility, UpdateTopicOptions, UpdateTopicResponse,
     };
     pub use super::webhooks::types::{
-        CreateWebhookOptions, CreateWebhookResponse, DeleteWebhookResponse, UpdateWebhookOptions,
-        UpdateWebhookResponse, Webhook, WebhookEvent, WebhookEventAttempt, WebhookEventAttemptId,
-        WebhookEventAttemptListResponse, WebhookEventDetails, WebhookEventId,
-        WebhookEventListResponse, WebhookEventStatus, WebhookId, WebhookStatus,
+        CreateWebhookOptions, CreateWebhookResponse, DeleteWebhookResponse,
+        ReplayWebhookEventResponse, UpdateWebhookOptions, UpdateWebhookResponse, Webhook,
+        WebhookEvent, WebhookEventAttempt, WebhookEventAttemptId, WebhookEventAttemptListResponse,
+        WebhookEventDetails, WebhookEventId, WebhookEventListResponse, WebhookEventStatus,
+        WebhookId, WebhookStatus,
     };
 }
 

--- a/src/webhooks.rs
+++ b/src/webhooks.rs
@@ -6,9 +6,9 @@ use crate::{
     Config, Result,
     list_opts::{AfterPagination, ListOptions, ListResponse},
     types::{
-        CreateWebhookOptions, CreateWebhookResponse, DeleteWebhookResponse, UpdateWebhookOptions,
-        UpdateWebhookResponse, Webhook, WebhookEventAttemptListResponse, WebhookEventDetails,
-        WebhookEventListResponse,
+        CreateWebhookOptions, CreateWebhookResponse, DeleteWebhookResponse,
+        ReplayWebhookEventResponse, UpdateWebhookOptions, UpdateWebhookResponse, Webhook,
+        WebhookEventAttemptListResponse, WebhookEventDetails, WebhookEventListResponse,
     },
 };
 
@@ -101,6 +101,23 @@ impl WebhookSvc {
         Ok(content)
     }
 
+    /// Queue one more delivery of a webhook event to its webhook.
+    ///
+    /// <https://resend.com/docs/api-reference/webhooks/replay-event>
+    #[maybe_async::maybe_async]
+    pub async fn replay_event(
+        &self,
+        webhook_id: &str,
+        event_id: &str,
+    ) -> Result<ReplayWebhookEventResponse> {
+        let path = format!("/webhooks/{webhook_id}/events/{event_id}/replay");
+        let request = self.0.build(Method::POST, &path);
+        let response = self.0.send(request).await?;
+        let content = response.json::<ReplayWebhookEventResponse>().await?;
+
+        Ok(content)
+    }
+
     /// Retrieve the delivery attempts for a webhook event.
     ///
     /// <https://resend.com/docs/api-reference/webhooks/list-event-attempts>
@@ -184,6 +201,13 @@ pub mod types {
         pub status: WebhookEventStatus,
         pub next_attempt_at: Option<String>,
         pub payload: Value,
+    }
+
+    #[must_use]
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    pub struct ReplayWebhookEventResponse {
+        pub object: String,
+        pub id: WebhookEventId,
     }
 
     #[must_use]


### PR DESCRIPTION
Adds `WebhookSvc::replay_event` for `POST /webhooks/{webhook_id}/events/{event_id}/replay`, next to `get_event`, plus the `ReplayWebhookEventResponse` type (re-exported from `resend_rs::types`). Replaying queues one more delivery of the event to the webhook, same as the dashboard's Replay button; manual replays do not schedule automatic retries.

Offered for the maintainer's review. Part of the webhook event replay rollout (DEV-2005).

```rust
pub async fn replay_event(&self, webhook_id: &str, event_id: &str) -> Result<ReplayWebhookEventResponse>
```

```rust
let replayed = resend
    .webhooks
    .replay_event(
        "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
        "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
    )
    .await?;
println!("{}", replayed.id);
```

References:
- Spec PR: https://github.com/resend/resend-openapi/pull/112
- Public API PR: https://github.com/resend/resend-monorepo/pull/9535
- Docs: https://resend.com/docs/api-reference/webhooks/replay-event

Checks run locally:
- `cargo build`: ok
- `cargo fmt --check`: ok
- `cargo clippy --all-targets -- -Dwarnings`: ok (async, `--no-default-features --features rustls-tls`, and `--features blocking`)
- `cargo test webhooks::` (async and `--features blocking`): offline tests pass. `webhooks::test::all` needs `RESEND_API_KEY` and was not run.

Not done: no live call against the endpoint (write endpoint, no key configured), so the response shape is taken from the spec PR. No new test: the response type is a two-field derive with nothing to regress, and the live `all` test cannot manufacture a deliverable event. No version bump, matching #101.

Linear: https://linear.app/resend/issue/DEV-2014
